### PR TITLE
fix(core): ロック解除時は一律でfilterも除去

### DIFF
--- a/src/core/assembly/random/lock.ts
+++ b/src/core/assembly/random/lock.ts
@@ -81,11 +81,11 @@ export class LockedParts {
   }
   unlock<K extends AssemblyKey>(target: K): LockedParts {
     const copyMap = { ...this.map }
-    const copyFilter = { ...this.filterMap }
     delete copyMap[target]
-    delete copyFilter[target]
 
-    return this.withMap(copyMap).withFilter(copyFilter)
+    // filterはロック時の特殊な状況でのみ必要なので、
+    // unlockでは一律解除で良い
+    return this.withMap(copyMap).clearFilter()
   }
   isLocking(key: AssemblyKey): boolean {
     return !!this.map[key]
@@ -109,6 +109,9 @@ export class LockedParts {
   }
   private withFilter(filter: LockedPartsFilter) {
     return new LockedParts(this.map, filter)
+  }
+  private clearFilter() {
+    return this.withFilter({})
   }
 }
 

--- a/src/view/App.svelte
+++ b/src/view/App.svelte
@@ -8,6 +8,7 @@
   import { logger } from '~core/utils/logger.ts'
   import {armNotEquipped} from "~data/arm-units.ts";
   import {backNotEquipped} from "~data/back-units.ts";
+  import {boosterNotEquipped} from "~data/booster.ts";
   import type {Candidates} from "~data/types/candidates.ts";
   import CoamRangeSlider from "./command/CoamRangeSlider.svelte";
   import LoadRangeSlider from "./command/LoadRangeSlider.svelte";
@@ -50,9 +51,11 @@
   }
 
   const onLock = (key: AssemblyKey) => (ev: CustomEvent<{ value: boolean }>) => {
+    console.log(ev.detail, lockedParts)
     lockedParts = ev.detail.value
       ? lockedParts.lock(key, assembly[key])
       : lockedParts.unlock(key)
+    console.log(lockedParts)
   }
   const onResetLock = () => {
     lockedParts = LockedParts.empty
@@ -193,7 +196,7 @@
       class="mb-3"
       caption="BOOSTER"
       tag="section"
-      parts={candidates.boosters}
+      parts={[...candidates.boosters, boosterNotEquipped]}
       selected={assembly.booster}
       lock={lockedParts}
       on:toggle-lock={onLock('booster')}


### PR DESCRIPTION
コメントの通り、filterはロック取得時にのみ必要な挙動であるため

resolves #53 