### PR TITLE
パッチ適用の関数を定義

### DIFF
--- a/data/types/candidates.ts
+++ b/data/types/candidates.ts
@@ -60,3 +60,25 @@ export function excludeNotEquipped<
 >(xs: readonly T[]): T[] {
   return xs.filter((x) => x.classification !== notEquipped)
 }
+
+/**
+ * UI上でのパーツの表示順序
+ */
+export type Order = Record<
+  keyof Candidates,
+  readonly string[]
+>
+export type OrderParts = <K extends keyof Candidates, P extends Candidates[K][number]>(key: K, parts: P[]) => readonly P[]
+export function defineOrder(order: Order): OrderParts {
+  return <K extends keyof Candidates, P extends Candidates[K][number]>(key: K, parts: P[]): readonly P[] => {
+    const namePartsMap = parts.reduce(
+      (acc, p) => ({ ...acc, [p.name]: p }),
+      {} as Record<string, P>
+    )
+
+    return order[key].reduce(
+      (acc, name) => [...acc, namePartsMap[name]],
+      [] as P[]
+    )
+  }
+}

--- a/data/types/candidates.ts
+++ b/data/types/candidates.ts
@@ -66,25 +66,25 @@ export function excludeNotEquipped<
  */
 export type Order = Record<keyof Candidates, readonly string[]>
 export type OrderParts = <
-  K extends keyof Candidates,
-  P extends Candidates[K][number],
+  K extends keyof Candidates
 >(
   key: K,
-  parts: P[],
-) => readonly P[]
+  parts: Candidates[K],
+) => Candidates[K]
 export function defineOrder(order: Order): OrderParts {
-  return <K extends keyof Candidates, P extends Candidates[K][number]>(
+  return <K extends keyof Candidates>(
     key: K,
-    parts: P[],
-  ): readonly P[] => {
+    parts: Candidates[K]
+  ): Candidates[K] => {
+    type NamePartsMap = Record<string, Candidates[K][number]>
     const namePartsMap = parts.reduce(
-      (acc, p) => ({ ...acc, [p.name]: p }),
-      {} as Record<string, P>,
+      (acc: NamePartsMap, p: Candidates[K][number]): NamePartsMap => ({ ...acc, [p.name]: p }),
+      {} as NamePartsMap,
     )
 
     return order[key].reduce(
-      (acc, name) => [...acc, namePartsMap[name]],
-      [] as P[],
+      (acc: Candidates[K], name): Candidates[K] => [...acc, namePartsMap[name]] as Candidates[K],
+      [] as Candidates[K],
     )
   }
 }

--- a/data/types/candidates.ts
+++ b/data/types/candidates.ts
@@ -64,21 +64,27 @@ export function excludeNotEquipped<
 /**
  * UI上でのパーツの表示順序
  */
-export type Order = Record<
-  keyof Candidates,
-  readonly string[]
->
-export type OrderParts = <K extends keyof Candidates, P extends Candidates[K][number]>(key: K, parts: P[]) => readonly P[]
+export type Order = Record<keyof Candidates, readonly string[]>
+export type OrderParts = <
+  K extends keyof Candidates,
+  P extends Candidates[K][number],
+>(
+  key: K,
+  parts: P[],
+) => readonly P[]
 export function defineOrder(order: Order): OrderParts {
-  return <K extends keyof Candidates, P extends Candidates[K][number]>(key: K, parts: P[]): readonly P[] => {
+  return <K extends keyof Candidates, P extends Candidates[K][number]>(
+    key: K,
+    parts: P[],
+  ): readonly P[] => {
     const namePartsMap = parts.reduce(
       (acc, p) => ({ ...acc, [p.name]: p }),
-      {} as Record<string, P>
+      {} as Record<string, P>,
     )
 
     return order[key].reduce(
       (acc, name) => [...acc, namePartsMap[name]],
-      [] as P[]
+      [] as P[],
     )
   }
 }

--- a/data/types/candidates.ts
+++ b/data/types/candidates.ts
@@ -65,25 +65,27 @@ export function excludeNotEquipped<
  * UI上でのパーツの表示順序
  */
 export type Order = Record<keyof Candidates, readonly string[]>
-export type OrderParts = <
-  K extends keyof Candidates
->(
+export type OrderParts = <K extends keyof Candidates>(
   key: K,
   parts: Candidates[K],
 ) => Candidates[K]
 export function defineOrder(order: Order): OrderParts {
   return <K extends keyof Candidates>(
     key: K,
-    parts: Candidates[K]
+    parts: Candidates[K],
   ): Candidates[K] => {
     type NamePartsMap = Record<string, Candidates[K][number]>
     const namePartsMap = parts.reduce(
-      (acc: NamePartsMap, p: Candidates[K][number]): NamePartsMap => ({ ...acc, [p.name]: p }),
+      (acc: NamePartsMap, p: Candidates[K][number]): NamePartsMap => ({
+        ...acc,
+        [p.name]: p,
+      }),
       {} as NamePartsMap,
     )
 
     return order[key].reduce(
-      (acc: Candidates[K], name): Candidates[K] => [...acc, namePartsMap[name]] as Candidates[K],
+      (acc: Candidates[K], name): Candidates[K] =>
+        [...acc, namePartsMap[name]] as Candidates[K],
       [] as Candidates[K],
     )
   }

--- a/data/types/inner/generator.ts
+++ b/data/types/inner/generator.ts
@@ -4,8 +4,8 @@ import type { Manufacture } from '~data/types/base/manufacture'
 
 import type { ACParts } from '../base/types'
 
-export const defineGenerator = <M extends Manufacture>(d: Generator<M>) => d
-export type Generator<M extends Manufacture> = Readonly<{
+export const defineGenerator = (d: Generator) => d
+export type Generator = Readonly<{
   /** EN容量 */
   en_capacity: number
   /** EN補充性能 */
@@ -19,4 +19,4 @@ export type Generator<M extends Manufacture> = Readonly<{
   /** EN出力 */
   en_output: number
 }> &
-  ACParts<Classification.Generator, M, Category.Generator>
+  ACParts<Classification.Generator, Manufacture, Category.Generator>

--- a/data/versions/patches.ts
+++ b/data/versions/patches.ts
@@ -1,0 +1,78 @@
+import type { Candidates } from '~data/types/candidates.ts'
+
+type Part = keyof Candidates
+type PatchForPart = <P extends Part>(key: P) => DefinePatch<P>
+
+type DefinePatch<P extends Part> = (
+  name: string,
+  apply: PatchFunction<P>,
+) => Patch
+type PatchFunction<P extends Part> = (
+  p: Candidates[P][number],
+) => Candidates[P][number]
+type Patch = (base: Candidates) => Candidates
+
+export function apply(base: Candidates, patches: readonly Patch[]): Candidates {
+  return patches.reduce((acc, p) => p(acc), base)
+}
+
+const defineUpdate: PatchForPart =
+  <P extends Part>(key: P) =>
+  (name, apply) =>
+  (base) => {
+    const xs = base[key]
+
+    const targetIndex = xs.findIndex((x) => x.name === name)
+    const target = xs[targetIndex] || null
+
+    if (!target) {
+      throw new Error(`${name} is not exist`)
+    }
+
+    const result = (() => {
+      const r = [...xs]
+
+      for (let i = 0; i < xs.length; i++) {
+        if (i === targetIndex) {
+          r[i] = apply(xs[i])
+
+          return r
+        }
+      }
+    })()
+
+    return { ...base, [key]: result }
+  }
+
+const defineAdd =
+  <P extends Part>(key: P) =>
+  (newItem: Candidates[P][number]) =>
+  (base: Candidates): Candidates => {
+    return {
+      ...base,
+      [key]: base[key].concat([newItem]),
+    }
+  }
+
+const definePatch = <P extends Part>(key: P) => ({
+  update: defineUpdate(key),
+  add: defineAdd(key),
+})
+
+export const patches = {
+  rightArmUnit: definePatch('rightArmUnit'),
+  leftArmUnit: definePatch('leftArmUnit'),
+  rightBackUnit: definePatch('rightBackUnit'),
+  leftBackUnit: definePatch('leftBackUnit'),
+
+  head: definePatch('head'),
+  arms: definePatch('arms'),
+  core: definePatch('core'),
+  legs: definePatch('legs'),
+
+  fcs: definePatch('fcs'),
+  booster: definePatch('booster'),
+  generator: definePatch('generator'),
+
+  expansion: definePatch('expansion'),
+}

--- a/data/versions/v1.06.1.ts
+++ b/data/versions/v1.06.1.ts
@@ -13,7 +13,8 @@ import {
   backNotEquipped,
   expansionNotEquipped,
 } from '~data/not-equipped.ts'
-import type { Candidates } from '~data/types/candidates.ts'
+import type {ACParts} from "~data/types/base/types.ts";
+import type {Candidates, Order} from '~data/types/candidates.ts'
 
 export const version = 'v1.06.1' as const
 export type VERSION = typeof version
@@ -55,3 +56,22 @@ export const candidates: Candidates = {
 
   expansion: [...expansions, expansionNotEquipped],
 } as const
+
+const toName = <T extends ACParts>(xs: readonly T[]): readonly T['name'][] => xs.map(x => x.name)
+export const orders: Order = {
+  rightArmUnit: toName(candidates.rightArmUnit),
+  leftArmUnit: toName(candidates.leftArmUnit),
+  rightBackUnit: toName(candidates.rightBackUnit),
+  leftBackUnit: toName(candidates.leftBackUnit),
+
+  head: toName(candidates.head),
+  core: toName(candidates.core),
+  arms: toName(candidates.arms),
+  legs: toName(candidates.legs),
+
+  booster: toName(candidates.booster),
+  fcs: toName(candidates.fcs),
+  generator: toName(candidates.generator),
+
+  expansion: toName(candidates.expansion),
+}

--- a/data/versions/v1.06.1.ts
+++ b/data/versions/v1.06.1.ts
@@ -13,8 +13,8 @@ import {
   backNotEquipped,
   expansionNotEquipped,
 } from '~data/not-equipped.ts'
-import type {ACParts} from "~data/types/base/types.ts";
-import type {Candidates, Order} from '~data/types/candidates.ts'
+import type { ACParts } from '~data/types/base/types.ts'
+import type { Candidates, Order } from '~data/types/candidates.ts'
 
 export const version = 'v1.06.1' as const
 export type VERSION = typeof version
@@ -57,7 +57,8 @@ export const candidates: Candidates = {
   expansion: [...expansions, expansionNotEquipped],
 } as const
 
-const toName = <T extends ACParts>(xs: readonly T[]): readonly T['name'][] => xs.map(x => x.name)
+const toName = <T extends ACParts>(xs: readonly T[]): readonly T['name'][] =>
+  xs.map((x) => x.name)
 export const orders: Order = {
   rightArmUnit: toName(candidates.rightArmUnit),
   leftArmUnit: toName(candidates.leftArmUnit),

--- a/data/versions/v1.07.ts
+++ b/data/versions/v1.07.ts
@@ -1,4 +1,4 @@
-import type {Order} from "~data/types/candidates.ts";
+import type { Order } from '~data/types/candidates.ts'
 import { apply } from '~data/versions/patches.ts'
 
 import { candidates as v1_06_1, orders as order_v1_06_1 } from './v1.06.1.ts'

--- a/data/versions/v1.07.ts
+++ b/data/versions/v1.07.ts
@@ -1,0 +1,10 @@
+import { apply } from '~data/versions/patches.ts'
+
+import { candidates as v1_06_1 } from './v1.06.1.ts'
+
+export const version = 'v1.07' as const
+export type VERSION = typeof version
+
+export const candidates = apply(v1_06_1, [
+  // define patches for v1.07
+])

--- a/data/versions/v1.07.ts
+++ b/data/versions/v1.07.ts
@@ -1,6 +1,7 @@
+import type {Order} from "~data/types/candidates.ts";
 import { apply } from '~data/versions/patches.ts'
 
-import { candidates as v1_06_1 } from './v1.06.1.ts'
+import { candidates as v1_06_1, orders as order_v1_06_1 } from './v1.06.1.ts'
 
 export const version = 'v1.07' as const
 export type VERSION = typeof version
@@ -8,3 +9,5 @@ export type VERSION = typeof version
 export const candidates = apply(v1_06_1, [
   // define patches for v1.07
 ])
+
+export const orders: Order = order_v1_06_1

--- a/src/core/assembly/candidates.ts
+++ b/src/core/assembly/candidates.ts
@@ -1,8 +1,12 @@
 import type { VERSION as v1_06_1 } from '~data/versions/v1.06.1.ts'
+import type { VERSION as v1_07 } from '~data/versions/v1.07.ts'
 
 export function getCandidates(
   version: v1_06_1,
 ): Promise<typeof import('~data/versions/v1.06.1.ts')>
+export function getCandidates(
+  version: v1_07,
+): Promise<typeof import('~data/versions/v1.07.ts')>
 export function getCandidates(version: string) {
   return import(`~data/versions/${version}.ts`)
 }

--- a/src/view/pages/index/Index.svelte
+++ b/src/view/pages/index/Index.svelte
@@ -42,6 +42,7 @@
   import ToolSection from "./layout/ToolSection.svelte"
 
   const appVersion = appPackage.version
+  const regulation = 'v1.06.1'
   const tryLimit = 3000
 
   // state
@@ -144,7 +145,7 @@
 
   // setup
   const initialize = async () => {
-    const version = await getCandidates('v1.06.1')
+    const version = await getCandidates(regulation)
 
     initialCandidates = candidates = version.candidates
     orderParts = defineOrder(version.orders)

--- a/src/view/pages/index/Index.svelte
+++ b/src/view/pages/index/Index.svelte
@@ -33,7 +33,7 @@
   import StoreAssembly from "~view/pages/index/store/StoreAssembly.svelte";
 
   import {notEquipped} from "~data/types/base/category.ts";
-  import type {Candidates} from "~data/types/candidates.ts";
+  import {type Candidates, defineOrder, type OrderParts} from "~data/types/candidates.ts";
 
   import appPackage from '~root/package.json'
 
@@ -57,6 +57,8 @@
   let openAssemblyStore: boolean = false
   let errorMessage: string[] = []
   let browserBacking: boolean = false
+
+  let orderParts: OrderParts
 
   $: {
     if (initialCandidates && filter && assembly && lockedParts) {
@@ -145,6 +147,7 @@
     const version = await getCandidates('v1.06.1')
 
     initialCandidates = candidates = version.candidates
+    orderParts = defineOrder(version.orders)
     filter = initialFilterState(initialCandidates)
 
     buildAssemblyFromQuery()
@@ -230,7 +233,7 @@
         class="mb-3 mb-sm-4"
         caption={spaceByWord(key).toUpperCase()}
         tag="section"
-        parts={candidates[key]}
+        parts={orderParts(key, candidates[key])}
         selected={assembly[key]}
         lock={lockedParts}
         filter={filter}

--- a/src/view/pages/index/form/PartsSelectForm.svelte
+++ b/src/view/pages/index/form/PartsSelectForm.svelte
@@ -2,12 +2,9 @@
   import type {AssemblyKey} from "~core/assembly/assembly.ts";
   import type {LockedParts} from "~core/assembly/random/lock.ts";
 
-  import type {Category} from "~data/types/base/category.ts";
-  import type {Classification} from "~data/types/base/classification.ts";
-  import type {Manufacture} from "~data/types/base/manufacture.ts";
   import type {ACParts} from "~data/types/base/types.ts";
 
-  export type ChangePartsEvent = Readonly<{ id: AssemblyKey, selected: ACParts<Classification, Manufacture, Category> }>
+  export type ChangePartsEvent = Readonly<{ id: AssemblyKey, selected: ACParts }>
   export type ToggleLockEvent = Readonly<{ id: AssemblyKey, value: boolean }>
   export type ToggleFilterEvent = Readonly<{ id: AssemblyKey }>
 </script>
@@ -22,8 +19,8 @@
 
   export let id: AssemblyKey
   export let caption: string
-  export let parts: readonly ACParts<Classification, Manufacture, Category>[]
-  export let selected: ACParts<Classification, Manufacture, Category>
+  export let parts: readonly ACParts[]
+  export let selected: ACParts
   export let tag = 'div'
   export let lock: LockedParts
   export let filter: FilterState


### PR DESCRIPTION
resolves #299 

1.07に備えて、過去のレギュレーションを元にパーツステータスの更新して新たな candidates を構築するための関数を追加