### PR TITLE
ステータス表示の桁数が小数表示の時におかしくなるのを修正

### DIFF
--- a/packages/web/src/pages/index/report/ReportItem.svelte
+++ b/packages/web/src/pages/index/report/ReportItem.svelte
@@ -2,6 +2,8 @@
   import type { ReportStatus } from '~view/pages/index/report/model/report'
 
   export let status: ReportStatus = 'normal'
+  export let caption: string
+  export let value: number
 
   const textClass = (base: string, stat: ReportStatus) => {
     switch(stat) {
@@ -16,6 +18,8 @@
 </script>
 
 <div class={$$props.class}>
-  <div class={captionClass}>{$$props.caption}</div>
-  <div class={valueClass}>{$$props.value}</div>
+  <div class={captionClass}>{caption}</div>
+  <div class={valueClass}>
+    {parseFloat(value.toFixed(2))}
+  </div>
 </div>


### PR DESCRIPTION
丸め誤差による差分か
厳密な計算が必要なわけではないので切り捨てで処理