### PR TITLE
タンク足選択でブースターの候補がNot Equippedのみの場合、ランダムアセンでエラーが起きるのを解消

### DIFF
--- a/packages/parts/src/types/candidates.ts
+++ b/packages/parts/src/types/candidates.ts
@@ -84,8 +84,11 @@ export function defineOrder(order: Order): OrderParts {
     )
 
     return order[key].reduce(
-      (acc: Candidates[K], name): Candidates[K] =>
-        [...acc, namePartsMap[name]] as Candidates[K],
+      (acc: Candidates[K], name): Candidates[K] => {
+        const item = namePartsMap[name]
+        
+        return (item ? [...acc, item] : acc) as Candidates[K]
+      },
       [] as Candidates[K],
     )
   }

--- a/packages/parts/src/types/candidates.ts
+++ b/packages/parts/src/types/candidates.ts
@@ -86,7 +86,7 @@ export function defineOrder(order: Order): OrderParts {
     return order[key].reduce(
       (acc: Candidates[K], name): Candidates[K] => {
         const item = namePartsMap[name]
-        
+
         return (item ? [...acc, item] : acc) as Candidates[K]
       },
       [] as Candidates[K],

--- a/packages/parts/src/versions/v1.06.1.ts
+++ b/packages/parts/src/versions/v1.06.1.ts
@@ -11,6 +11,7 @@ import { legs } from '~parts/legs'
 import {
   armNotEquipped,
   backNotEquipped,
+  boosterNotEquipped,
   expansionNotEquipped,
 } from '~parts/not-equipped'
 import type { ACParts } from '~parts/types/base/types'
@@ -70,7 +71,7 @@ export const orders: Order = {
   arms: toName(candidates.arms),
   legs: toName(candidates.legs),
 
-  booster: toName(candidates.booster),
+  booster: toName(candidates.booster.concat(boosterNotEquipped)),
   fcs: toName(candidates.fcs),
   generator: toName(candidates.generator),
 


### PR DESCRIPTION
resolves #349 

- orderに指定されたパーツが存在しない可能性を追加
- boosterのorder指定にNotEquippedを追加