### PR TITLE
スマホでのランダムアセン・ロック解除のUI配置を調整

### DIFF
--- a/packages/web/src/i18n/locales/en/filter.ts
+++ b/packages/web/src/i18n/locales/en/filter.ts
@@ -2,7 +2,7 @@ import { onlyPropertyIncludedInList } from '@ac6_assemble_tool/core/assembly/fil
 import type { Unit } from '@ac6_assemble_tool/parts/units'
 
 export const enFilter = {
-  filter: 'filter',
+  filter: 'Filter',
   excludeNotEquipped: 'exclude not-equipped',
   notUseHanger: 'not use hanger',
   excludeAllNotEquipped: 'exclude any not-equipped',

--- a/packages/web/src/i18n/locales/en/pages/index.ts
+++ b/packages/web/src/i18n/locales/en/pages/index.ts
@@ -5,11 +5,11 @@ export const enPageIndex = {
       description: 'Configure Random Assemble',
     },
     resetLock: {
-      label: 'Reset All Locks',
+      label: 'Reset Locks',
       description: 'Reset All Locks',
     },
     filterForWhole: {
-      label: 'Set Filter',
+      label: 'Filter',
       description: 'Set filter for whole of assembly',
     },
     share: {
@@ -29,7 +29,7 @@ export const enPageIndex = {
       hide: 'Hide',
     },
     store: {
-      label: 'Store Assembly',
+      label: 'Store',
       description: 'Store Assembly and Apply',
     },
   },

--- a/packages/web/src/i18n/locales/en/pages/index.ts
+++ b/packages/web/src/i18n/locales/en/pages/index.ts
@@ -1,14 +1,15 @@
 export const enPageIndex = {
   command: {
     random: {
-      label: 'Random Assemble',
-      description: 'Generate an assembly randomly',
+      label: 'Random Config',
+      description: 'Configure Random Assemble',
     },
     resetLock: {
-      description: 'Reset all locks',
+      description: 'Reset All Locks',
     },
     filterForWhole: {
-      description: 'Set conditions to assemble',
+      label: 'Set Filter',
+      description: 'Set filter for whole of assembly',
     },
     share: {
       caption: "$t(share:command.target.caption, {'what': 'Current Assembly'})",

--- a/packages/web/src/i18n/locales/en/pages/index.ts
+++ b/packages/web/src/i18n/locales/en/pages/index.ts
@@ -14,7 +14,8 @@ export const enPageIndex = {
     },
     share: {
       label: 'Share',
-      description: "$t(share:command.target.caption, {'what': 'Current Assembly'})",
+      description:
+        "$t(share:command.target.caption, {'what': 'Current Assembly'})",
       text: {
         label: 'Copy',
         description: 'Copy current assembly',

--- a/packages/web/src/i18n/locales/en/pages/index.ts
+++ b/packages/web/src/i18n/locales/en/pages/index.ts
@@ -5,6 +5,7 @@ export const enPageIndex = {
       description: 'Configure Random Assemble',
     },
     resetLock: {
+      label: 'Reset All Locks',
       description: 'Reset All Locks',
     },
     filterForWhole: {
@@ -12,7 +13,8 @@ export const enPageIndex = {
       description: 'Set filter for whole of assembly',
     },
     share: {
-      caption: "$t(share:command.target.caption, {'what': 'Current Assembly'})",
+      label: 'Share',
+      description: "$t(share:command.target.caption, {'what': 'Current Assembly'})",
       text: {
         label: 'Copy',
         description: 'Copy current assembly',
@@ -27,7 +29,8 @@ export const enPageIndex = {
       hide: 'Hide',
     },
     store: {
-      caption: 'Store Assembly',
+      label: 'Store Assembly',
+      description: 'Store Assembly and Apply',
     },
   },
   report: {

--- a/packages/web/src/i18n/locales/en/random.ts
+++ b/packages/web/src/i18n/locales/en/random.ts
@@ -1,7 +1,7 @@
 export const enRandom = {
   command: {
     random: {
-      label: 'Run Assemble',
+      label: 'Run Random Assemble',
     },
     disallow_over_load: {
       label: 'Disallow Over Load',

--- a/packages/web/src/i18n/locales/en/share.ts
+++ b/packages/web/src/i18n/locales/en/share.ts
@@ -1,5 +1,5 @@
 export const enShare = {
-  caption: 'Share',
+  caption: 'Share Assembly',
   command: {
     target: {
       caption: 'Share {{what}}',

--- a/packages/web/src/i18n/locales/ja/pages/index.ts
+++ b/packages/web/src/i18n/locales/ja/pages/index.ts
@@ -13,7 +13,7 @@ export const jaPageIndex = {
       description: 'アセンブルの<br>条件を設定する',
     },
     share: {
-      label: "共有",
+      label: '共有',
       description: "$t(share:command.target.caption, {'what': '現在のアセン'})",
       text: {
         label: 'コピー',

--- a/packages/web/src/i18n/locales/ja/pages/index.ts
+++ b/packages/web/src/i18n/locales/ja/pages/index.ts
@@ -30,7 +30,7 @@ export const jaPageIndex = {
     },
     store: {
       label: 'アセン保存',
-      description: 'アセンデータを保存・適用する',
+      description: 'アセンデータを<br/>保存・適用する',
     },
   },
   report: {

--- a/packages/web/src/i18n/locales/ja/pages/index.ts
+++ b/packages/web/src/i18n/locales/ja/pages/index.ts
@@ -8,6 +8,7 @@ export const jaPageIndex = {
       description: 'ロックを全て解除する',
     },
     filterForWhole: {
+      label: '絞り込み',
       description: 'アセンブルの<br>条件を設定する',
     },
     share: {

--- a/packages/web/src/i18n/locales/ja/pages/index.ts
+++ b/packages/web/src/i18n/locales/ja/pages/index.ts
@@ -5,6 +5,7 @@ export const jaPageIndex = {
       description: 'ランダムアセンの<br/>条件を設定する',
     },
     resetLock: {
+      label: '全ロック解除',
       description: 'ロックを全て解除する',
     },
     filterForWhole: {
@@ -12,7 +13,8 @@ export const jaPageIndex = {
       description: 'アセンブルの<br>条件を設定する',
     },
     share: {
-      caption: "$t(share:command.target.caption, {'what': '現在のアセン'})",
+      label: "共有",
+      description: "$t(share:command.target.caption, {'what': '現在のアセン'})",
       text: {
         label: 'コピー',
         description: '現在のアセンブルをコピー',
@@ -27,7 +29,8 @@ export const jaPageIndex = {
       hide: '表示しない',
     },
     store: {
-      caption: 'アセンデータ管理',
+      label: 'アセン保存',
+      description: 'アセンデータを保存・適用する',
     },
   },
   report: {

--- a/packages/web/src/i18n/locales/ja/pages/index.ts
+++ b/packages/web/src/i18n/locales/ja/pages/index.ts
@@ -1,8 +1,8 @@
 export const jaPageIndex = {
   command: {
     random: {
-      label: 'ランダムアセン',
-      description: '条件を満たすアセンを<br>ランダムに生成する',
+      label: 'ランダム設定',
+      description: 'ランダムアセンの<br/>条件を設定する',
     },
     resetLock: {
       description: 'ロックを全て解除する',

--- a/packages/web/src/i18n/locales/ja/random.ts
+++ b/packages/web/src/i18n/locales/ja/random.ts
@@ -1,7 +1,7 @@
 export const jaRandom = {
   command: {
     random: {
-      label: 'アセンブル実行',
+      label: 'ランダムアセン実行',
     },
     disallow_over_load: {
       label: '積載超過を禁止',

--- a/packages/web/src/i18n/locales/ja/share.ts
+++ b/packages/web/src/i18n/locales/ja/share.ts
@@ -1,5 +1,5 @@
 export const jaShare = {
-  caption: '共有する',
+  caption: 'アセン共有',
   command: {
     target: {
       caption: '{{what}}を共有する',

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -170,7 +170,7 @@
     on:click={() => lockedParts = LockedParts.empty}
   >
     <i slot="icon" class="bi bi-unlock"></i>
-    {$i18n.t('resetAllLock', { ns: 'lock' })}
+    {$i18n.t('command.resetLock.description', { ns: 'page/index' })}
   </NavButton>
   <NavButton
     id="open-whole-filter"
@@ -179,7 +179,7 @@
     on:click={() => openWholeFilter = true}
   >
     <i slot="icon" class="bi bi-filter-square"></i>
-    {$i18n.t('filter', { ns: 'filter' })}
+    {$i18n.t('command.filterForWhole.label', { ns: 'page/index' })}
   </NavButton>
   <NavButton
     id="open-share"

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -201,7 +201,7 @@
 
 <header class="text-center mt-5">
   <h1>
-    ARMORED CORE Ⅵ<br class="sp-only">
+    ARMORED CORE Ⅵ<br class="d-block d-md-none">
     ASSEMBLY TOOL
   </h1>
   <h2>

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -162,7 +162,9 @@
     on:click={() => openRandomAssembly = true}
   >
     <i slot="icon" class="bi bi-tools"></i>
-    {$i18n.t('command.random.label', { ns: 'page/index' })}
+    <span class="d-none d-md-inline">
+      {$i18n.t('command.random.label', { ns: 'page/index' })}
+    </span>
   </NavButton>
   <NavButton
     id="reset-lock-nav"
@@ -171,7 +173,9 @@
     on:click={() => lockedParts = LockedParts.empty}
   >
     <i slot="icon" class="bi bi-unlock"></i>
-    {$i18n.t('command.resetLock.label', { ns: 'page/index' })}
+    <span class="d-none d-md-inline">
+      {$i18n.t('command.resetLock.label', { ns: 'page/index' })}
+    </span>
   </NavButton>
   <NavButton
     id="open-whole-filter"
@@ -180,7 +184,9 @@
     on:click={() => openWholeFilter = true}
   >
     <i slot="icon" class="bi bi-filter-square"></i>
-    {$i18n.t('command.filterForWhole.label', { ns: 'page/index' })}
+    <span class="d-none d-md-inline">
+      {$i18n.t('command.filterForWhole.label', { ns: 'page/index' })}
+    </span>
   </NavButton>
   <NavButton
     id="open-share"
@@ -189,7 +195,9 @@
     on:click={() => openShare = true}
   >
     <i slot="icon" class="bi bi-share"></i>
-    {$i18n.t('command.share.label', { ns: 'page/index'})}
+    <span class="d-none d-md-inline">
+      {$i18n.t('command.share.label', { ns: 'page/index'})}
+    </span>
   </NavButton>
   <NavButton
     id="open-assembly-store"
@@ -197,7 +205,9 @@
     on:click={() => openAssemblyStore = true}
   >
     <i slot="icon" class="bi bi-database"></i>
-    {$i18n.t('command.store.label', { ns: 'page/index'})}
+    <span class="d-none d-md-inline">
+      {$i18n.t('command.store.label', { ns: 'page/index'})}
+    </span>
   </NavButton>
 </Navbar>
 

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -41,6 +41,7 @@
   import ShareAssembly from './share/ShareAssembly.svelte'
   import StoreAssembly from "./store/StoreAssembly.svelte";
   import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
+  import TextButton from '~view/components/button/TextButton.svelte'
 
   const appVersion = appPackage.version
   const regulation = 'v1.07'
@@ -164,8 +165,8 @@
     {$i18n.t('command.random.label', { ns: 'page/index' })}
   </NavButton>
   <NavButton
-    id="reset-lock"
-    class="me-3"
+    id="reset-lock-nav"
+    class="me-3 d-none d-md-block"
     title={$i18n.t('command.resetLock.description', { ns: 'page/index' })}
     on:click={() => lockedParts = LockedParts.empty}
   >
@@ -215,15 +216,23 @@
 
 <article class="container text-center px-3">
   <ToolSection id="candidates-form" class="my-4 w-100">
-    <div class="d-flex d-sm-none justify-content-end">
+    <div class="d-flex d-md-none justify-content-end">
       <RandomAssembleButton
         initialCandidates={initialCandidates}
         candidates={candidates}
         lockedParts={lockedParts}
         randomAssembly={randomAssembly}
         aria-label={$i18n.t('random:command.random.label')}
+        class="me-3"
         on:click={({ detail: randomAssembly }) => assembly = randomAssembly}
       />
+      <TextButton
+        id="reset-lock-form"
+        title={$i18n.t('command.resetLock.description', { ns: 'page/index' })}
+        on:click={() => lockedParts = LockedParts.empty}
+      >
+        <i class="bi bi-unlock"></i>
+      </TextButton>
     </div>
     <hr class="w-100 d-flex d-md-none">
     {#each assemblyKeys() as key}

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -40,6 +40,7 @@
   import ReportList from './report/ReportList.svelte'
   import ShareAssembly from './share/ShareAssembly.svelte'
   import StoreAssembly from "./store/StoreAssembly.svelte";
+  import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
 
   const appVersion = appPackage.version
   const regulation = 'v1.07'
@@ -214,6 +215,17 @@
 
 <article class="container text-center px-3">
   <ToolSection id="candidates-form" class="my-4 w-100">
+    <div class="d-flex d-sm-none justify-content-end">
+      <RandomAssembleButton
+        initialCandidates={initialCandidates}
+        candidates={candidates}
+        lockedParts={lockedParts}
+        randomAssembly={randomAssembly}
+        aria-label={$i18n.t('random:command.random.label')}
+        on:click={({ detail: randomAssembly }) => assembly = randomAssembly}
+      />
+    </div>
+    <hr class="w-100 d-flex d-md-none">
     {#each assemblyKeys() as key}
       <PartsSelectForm
         id={key}

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -1,10 +1,12 @@
 
 <script lang="ts">
 
+  import TextButton from '~view/components/button/TextButton.svelte'
   import LanguageForm from "~view/components/language/LanguageForm.svelte";
   import ErrorModal from "~view/components/modal/ErrorModal.svelte";
   import Margin from "~view/components/spacing/Margin.svelte";
   import i18n from "~view/i18n/define";
+  import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
   import RandomAssemblyOffCanvas, { type AssembleRandomly, type ErrorOnAssembly } from '~view/pages/index/random/RandomAssemblyOffCanvas.svelte'
   import {logger} from "~view/utils/logger";
 
@@ -40,8 +42,6 @@
   import ReportList from './report/ReportList.svelte'
   import ShareAssembly from './share/ShareAssembly.svelte'
   import StoreAssembly from "./store/StoreAssembly.svelte";
-  import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
-  import TextButton from '~view/components/button/TextButton.svelte'
 
   const appVersion = appPackage.version
   const regulation = 'v1.07'

--- a/packages/web/src/pages/index/Index.svelte
+++ b/packages/web/src/pages/index/Index.svelte
@@ -170,7 +170,7 @@
     on:click={() => lockedParts = LockedParts.empty}
   >
     <i slot="icon" class="bi bi-unlock"></i>
-    {$i18n.t('command.resetLock.description', { ns: 'page/index' })}
+    {$i18n.t('command.resetLock.label', { ns: 'page/index' })}
   </NavButton>
   <NavButton
     id="open-whole-filter"
@@ -184,19 +184,19 @@
   <NavButton
     id="open-share"
     class="me-3"
-    title={$i18n.t('share:caption')}
+    title={$i18n.t('command.share.description', { ns: 'page/index'})}
     on:click={() => openShare = true}
   >
     <i slot="icon" class="bi bi-share"></i>
-    {$i18n.t('share:caption')}
+    {$i18n.t('command.share.label', { ns: 'page/index'})}
   </NavButton>
   <NavButton
     id="open-assembly-store"
-    title={$i18n.t('command.store.caption', { ns: 'page/index'})}
+    title={$i18n.t('command.store.description', { ns: 'page/index'})}
     on:click={() => openAssemblyStore = true}
   >
     <i slot="icon" class="bi bi-database"></i>
-    {$i18n.t('command.store.caption', { ns: 'page/index'})}
+    {$i18n.t('command.store.label', { ns: 'page/index'})}
   </NavButton>
 </Navbar>
 
@@ -355,7 +355,7 @@
   on:toggle={(e) => openShare = e.detail.open}
 >
   <svelte:fragment slot="title">
-    {$i18n.t('command.share.caption', { ns: 'page/index' })}
+    {$i18n.t('share:caption')}
   </svelte:fragment>
 </ShareAssembly>
 <StoreAssembly

--- a/packages/web/src/pages/index/app.scss
+++ b/packages/web/src/pages/index/app.scss
@@ -4,9 +4,3 @@
 :root {
   --bs-font-monospace: 'DM Mono', 'Sawarabi Gothic', monospace;
 }
-
-@include media-breakpoint-up(md) {
-  .sp-only {
-    display: none;
-  }
-}

--- a/packages/web/src/pages/index/filter/FilterByPartsOffCanvas.svelte
+++ b/packages/web/src/pages/index/filter/FilterByPartsOffCanvas.svelte
@@ -39,7 +39,9 @@
   on:toggle={(e) => dispatch('toggle', e.detail)}
 >
   <svelte:fragment slot="title">
-    {`${current.name || ''} FILTER`}
+    <span class="text-uppercase">
+      {`${current.name || ''} FILTER`}
+    </span>
   </svelte:fragment>
   <svelte:fragment slot="body">
     {#each current.filter.list as f}

--- a/packages/web/src/pages/index/layout/navbar/NavButton.svelte
+++ b/packages/web/src/pages/index/layout/navbar/NavButton.svelte
@@ -41,7 +41,5 @@
   action={setupTooltip}
 >
   <slot name="icon"></slot>
-  <span class="d-none d-sm-inline">
-    <slot></slot>
-  </span>
+  <slot></slot>
 </TextButton>

--- a/packages/web/src/pages/index/random/RandomAssemblyOffCanvas.svelte
+++ b/packages/web/src/pages/index/random/RandomAssemblyOffCanvas.svelte
@@ -17,6 +17,7 @@
   import OffCanvas from '~view/components/off-canvas/OffCanvas.svelte'
   import Margin from '~view/components/spacing/Margin.svelte'
   import i18n from "~view/i18n/define";
+  import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
   import { logger } from '~view/utils/logger'
 
   import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly'
@@ -28,7 +29,6 @@
 
   import CoamRangeSlider from './range/CoamRangeSlider.svelte'
   import LoadRangeSlider, { type ToggleLock } from './range/LoadRangeSlider.svelte'
-  import RandomAssembleButton from '~view/pages/index/random/button/RandomAssembleButton.svelte'
 
   export let open: boolean
   export let lockedParts: LockedParts

--- a/packages/web/src/pages/index/random/button/RandomAssembleButton.svelte
+++ b/packages/web/src/pages/index/random/button/RandomAssembleButton.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+
+  import type { LockedParts } from '@ac6_assemble_tool/core/assembly/random/lock'
+  import type { RandomAssembly } from '@ac6_assemble_tool/core/assembly/random/random-assembly'
+  import { notEquipped } from '@ac6_assemble_tool/parts/types/base/category'
+  import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
+  import { logger } from '~view/utils/logger'
+  import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly.d'
+  import TextButton from '~view/components/button/TextButton.svelte'
+
+  export let lockedParts: LockedParts
+  export let initialCandidates: Candidates
+  export let candidates: Candidates
+  export let randomAssembly: RandomAssembly
+
+  // handler
+  const onRandom = () => {
+    try {
+      logger.debug('on random', lockedParts, candidates.booster)
+      const actualCandidates = (
+        !lockedParts.isLocking('legs')
+        && candidates.booster.length === 1
+        && candidates.booster[0].category === notEquipped
+      )
+        // 脚部がロックされていないのに候補が未装備のみなら、たまたまタンク脚が選択されているだけなので
+        // ランダムアセン時にブースターを制限する必要は無い
+        // この処置が必要になるのはランダムアセン時のみなので、filterの処理には含めない
+        ? { ...candidates, booster: initialCandidates.booster }
+        : candidates
+
+      dispatch('click', randomAssembly.assemble(actualCandidates, { lockedParts }))
+    } catch (e) {
+      logger.error(e)
+
+      dispatch('error', e instanceof Error ? e : new Error(`${e}`))
+    }
+  }
+
+  // setup
+  const dispatch = createEventDispatcher<{
+    click: Assembly
+    error: Error
+  }>()
+</script>
+
+<TextButton
+  type="button"
+  {...$$restProps}
+  on:click={onRandom}
+>
+  <i class="bi bi-shuffle"></i>
+  <span class="d-none d-md-inline">
+    <slot></slot>
+  </span>
+</TextButton>

--- a/packages/web/src/pages/index/random/button/RandomAssembleButton.svelte
+++ b/packages/web/src/pages/index/random/button/RandomAssembleButton.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import TextButton from '~view/components/button/TextButton.svelte'
+  import { logger } from '~view/utils/logger'
 
+  import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly.d'
   import type { LockedParts } from '@ac6_assemble_tool/core/assembly/random/lock'
   import type { RandomAssembly } from '@ac6_assemble_tool/core/assembly/random/random-assembly'
   import { notEquipped } from '@ac6_assemble_tool/parts/types/base/category'
   import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
-  import { logger } from '~view/utils/logger'
-  import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly.d'
-  import TextButton from '~view/components/button/TextButton.svelte'
+  import { createEventDispatcher } from 'svelte'
 
   export let lockedParts: LockedParts
   export let initialCandidates: Candidates

--- a/packages/web/src/pages/index/random/range/base/RangeSlider.svelte
+++ b/packages/web/src/pages/index/random/range/base/RangeSlider.svelte
@@ -59,7 +59,7 @@
     on:change={onChange}
     list={`${id}-range-mark`}
   />
-  <datalist id={`${id}-range-mark`} class="sp-only w-100">
+  <datalist id={`${id}-range-mark`} class="d-sm-block d-md-none w-100">
     {#each dataList as v}
       <option value={v} label={`${v}`}>{v}</option>
     {/each}


### PR DESCRIPTION
スマホやタブレットなど、横幅が狭い状態ではランダムアセン・ロック解除ボタンの表示位置を変更

- ランダムアセンボタン → 横幅が狭いとcanvasで画面が隠れ、「結果を確認しながらランダムアセン」といった操作ができないため
- ロック解除ボタン → 横幅が狭い状態でのnav領域を確保するため。単発操作のためにnav領域を使うのはもったいない
    - よりパーツ選択と近い場所に配置したかった、という理由もある