### PR TITLE
tooltipがタップでは表示されないように変更

### DIFF
--- a/packages/web/src/components/button/IconButton.svelte
+++ b/packages/web/src/components/button/IconButton.svelte
@@ -41,6 +41,7 @@ const dispatch = createEventDispatcher<{ click: null }>()
   data-bs-title={title}
   data-bs-html="true"
   data-clickable={clickable}
+  data-bs-trigger="hover"
   aria-label={title}
   use:bindTooltip
   on:click={onClick}

--- a/packages/web/src/pages/index/layout/navbar/NavButton.svelte
+++ b/packages/web/src/pages/index/layout/navbar/NavButton.svelte
@@ -36,6 +36,7 @@
   data-bs-title={title}
   data-bs-placement="left"
   data-bs-html="true"
+  data-bs-trigger="hover"
   aria-label={title}
   on:click={onClick}
   action={setupTooltip}


### PR DESCRIPTION
タップでtooltipが表示されると単純に邪魔なので、hoverのみを対象にした
ただし、キーボードによるフォーカス移動によってもtooltipは表示されなくなった