### PR TITLE
web: show app version with commit hash (no SvelteKit version)

### DIFF
--- a/packages/web/src/lib/utils/app-version.ts
+++ b/packages/web/src/lib/utils/app-version.ts
@@ -1,0 +1,8 @@
+// App version string displayed in the UI
+// Injected at build-time via Vite's `define` in vite.config.ts
+// Falls back to 'dev' if not defined.
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - __APP_VERSION__ is defined by Vite
+export const appVersion: string =
+  typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -5,6 +5,7 @@
   import Margin from '$lib/components/spacing/Margin.svelte'
   import i18n from '$lib/i18n/define'
   import { useWithEnableState } from '$lib/ssg/safety-reference'
+  import { appVersion } from '$lib/utils/app-version'
   import { logger } from '$lib/utils/logger'
 
   import {
@@ -61,7 +62,6 @@
   import ShareAssembly from './share/ShareAssembly.svelte'
   import StoreAssembly from './store/StoreAssembly.svelte'
 
-  import { version as appVersion } from '$app/environment'
   import {
     PUBLIC_REPORT_BUG_URL,
     PUBLIC_REPORT_REQUEST_URL,

--- a/packages/web/src/types/app-version.d.ts
+++ b/packages/web/src/types/app-version.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -1,5 +1,4 @@
-import { execSync } from 'child_process'
-import fs from 'fs'
+// no-op
 
 import adapter from '@sveltejs/adapter-static'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
@@ -18,25 +17,9 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
  *
  * 根本的にはESLint側のサポートを待つしか無さそう
  */
-// import pkg from './package.json' with { type: 'json' }
-const pkg = (() => {
-  const raw = fs.readFileSync('package.json', { encoding: 'utf-8' })
+// NOTE: no SvelteKit versioning; package.json read not required here
 
-  return JSON.parse(raw)
-})()
-
-const shortHash = (() => {
-  try {
-    if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 7)
-    const out = execSync('git rev-parse --short HEAD', {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-    return out.trim()
-  } catch {
-    return 'dev'
-  }
-})()
+// NOTE: SvelteKit versioning is not used; handled via Vite define
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -45,10 +28,6 @@ const config = {
   preprocess: vitePreprocess(),
 
   kit: {
-    version: {
-      // Expose version like "1.22.0-<short-hash>" to $app/environment.version
-      name: `${pkg.version}-${shortHash}`,
-    },
     adapter: adapter({
       pages: 'dist',
       assets: 'dist',

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process'
 import fs from 'fs'
 
 import adapter from '@sveltejs/adapter-static'
@@ -24,6 +25,19 @@ const pkg = (() => {
   return JSON.parse(raw)
 })()
 
+const shortHash = (() => {
+  try {
+    if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 7)
+    const out = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return out.trim()
+  } catch {
+    return 'dev'
+  }
+})()
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   // Consult https://kit.svelte.dev/docs/integrations#preprocessors
@@ -32,7 +46,8 @@ const config = {
 
   kit: {
     version: {
-      name: pkg.version,
+      // Expose version like "1.22.0-<short-hash>" to $app/environment.version
+      name: `${pkg.version}-${shortHash}`,
     },
     adapter: adapter({
       pages: 'dist',

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,9 +1,33 @@
+import { execSync } from 'child_process'
+import fs from 'fs'
+
 import { sveltekit } from '@sveltejs/kit/vite'
 import { svelteTesting } from '@testing-library/svelte/vite'
 import { analyzer } from 'vite-bundle-analyzer'
 import { defineConfig } from 'vitest/config'
 
+const pkg = (() => {
+  const raw = fs.readFileSync('package.json', { encoding: 'utf-8' })
+  return JSON.parse(raw)
+})()
+
+const shortHash = (() => {
+  try {
+    if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 7)
+    const out = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return out.trim()
+  } catch {
+    return 'dev'
+  }
+})()
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(`${pkg.version}-${shortHash}`),
+  },
   plugins: [
     sveltekit(),
     svelteTesting(),


### PR DESCRIPTION
目的
- アプリケーションバージョンとコミットハッシュを併記し、依存更新のみ等の内部更新でも反映を確認できるようにする
- SvelteKitの `kit.version` は使用しない（キャッシュバスティング用途にも使わない）

変更内容
- web/vite.config.ts:
  - `__APP_VERSION__` を `pkg.version-<short-hash>` 形式で `define` 経由注入
  - ハッシュは `GITHUB_SHA`（7桁）を優先、無い場合は `git rev-parse --short HEAD`、それも無い場合は `dev`
- web/src/lib/utils/app-version.ts:
  - `__APP_VERSION__` を参照し、未定義時は `dev` を返すユーティリティを追加
- web/src/types/app-version.d.ts:
  - グローバル定数 `__APP_VERSION__` の型定義を追加
- web/src/lib/view/index/Index.svelte:
  - フッターの表示を `$app/environment.version` から新ユーティリティに差し替え
- web/svelte.config.js:
  - `kit.version` の設定とそれに付随する処理を削除

動作/影響
- フッターの表示は `v1.22.0-abcdef1` のような形式になります
- SvelteKitのバージョン管理（`$app/environment.version`）には依存しません
- GitHub Actions / ローカルいずれもハッシュ埋め込みが可能（環境によりフォールバック）

補足
- 既存のワークフローは変更していません（`GITHUB_SHA` によりCIでは自動でハッシュが入ります）

