### PR TITLE
font-sizeをpxからremへ変更（フォントサイズのみ）

### DIFF
--- a/packages/web/src/lib/components/button/IconButton.svelte
+++ b/packages/web/src/lib/components/button/IconButton.svelte
@@ -38,7 +38,7 @@
     cursor: pointer;
   }
   .icon-button {
-    font-size: 30px;
+    font-size: 1.875rem;
     height: 48px;
     text-align: center;
     width: 48px;

--- a/packages/web/src/lib/view/index/store/StoreAssembly.svelte
+++ b/packages/web/src/lib/view/index/store/StoreAssembly.svelte
@@ -134,7 +134,7 @@ ${target.description}
       clickable={true}
       withTooltip={true}
       class="bi bi-info-circle"
-      style="font-size: 18px;"
+      style="font-size: 1.125rem;"
     />
   </svelte:fragment>
   <svelte:fragment slot="body">


### PR DESCRIPTION
以下の通り、px指定のfont-sizeをremへ変更しました。\n\n- IconButton: 30px -> 1.875rem（font-sizeのみ変更）\n- StoreAssembly: 18px -> 1.125rem（inline style）\n\n背景:\n- ブラウザの基本フォントサイズ変更に追従し、アクセシビリティを改善するため。\n- 1rem=16pxを前提に既存の見た目を維持。\n\n影響範囲:\n- 検索確認: font-sizeのpx指定は上記2箇所のみ。その他のpxは未変更（高さ/幅などは今回スコープ外）。\n\nClose #119