### PR TITLE
ci: pin npm to 11.5.2 in workflows (for renovate/npm-11.x)

### DIFF
--- a/.github/workflows/_google-app-scripts-deploy.yml
+++ b/.github/workflows/_google-app-scripts-deploy.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: '.node-version'
-      - name: Install npm@11.4.0 (global)
+      - name: Install npm@11.5.2 (global)
         run: |
-          npm i -g npm@11.4.0
+          npm i -g npm@11.5.2
           npm --version
       - run: npm ci
         working-directory: scripts/google-app-scripts

--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: rebuild sass-embedded
+        run: npm rebuild sass-embedded
+
       - name: Build (Turborepo)
         run: npm run build:ci
         env:

--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: rebuild sass-embedded
-        run: npm rebuild sass-embedded
-
       - name: Build (Turborepo)
         run: npm run build:ci
         env:

--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'npm'
-      - name: Install npm@11.4.0 (global)
+      - name: Install npm@11.5.2 (global)
         run: |
-          npm i -g npm@11.4.0
+          npm i -g npm@11.5.2
           npm --version
 
       - name: Install

--- a/.github/workflows/ci-lighthouse.yml
+++ b/.github/workflows/ci-lighthouse.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'npm'
-      - name: Install npm@11.4.0 (global)
+      - name: Install npm@11.5.2 (global)
         run: |
-          npm i -g npm@11.4.0
+          npm i -g npm@11.5.2
           npm --version
       - name: setup
         run: npm ci

--- a/.github/workflows/ci-lighthouse.yml
+++ b/.github/workflows/ci-lighthouse.yml
@@ -22,9 +22,6 @@ jobs:
       - name: setup
         run: npm ci
 
-      - name: rebuild sass-embedded
-        run: npm rebuild sass-embedded
-
       # build
       - run: npm run build:ci
 

--- a/.github/workflows/ci-lighthouse.yml
+++ b/.github/workflows/ci-lighthouse.yml
@@ -22,6 +22,9 @@ jobs:
       - name: setup
         run: npm ci
 
+      - name: rebuild sass-embedded
+        run: npm rebuild sass-embedded
+
       # build
       - run: npm run build:ci
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'npm'
-      - name: Install npm@11.4.0 (global)
+      - name: Install npm@11.5.2 (global)
         run: |
-          npm i -g npm@11.4.0
+          npm i -g npm@11.5.2
           npm --version
       - name: setup
         run: npm ci

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -24,6 +24,9 @@ jobs:
       - name: setup
         run: npm ci
 
+      - name: rebuild sass-embedded
+        run: npm rebuild sass-embedded
+
       # build
       - run: npm run build:ci
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -24,9 +24,6 @@ jobs:
       - name: setup
         run: npm ci
 
-      - name: rebuild sass-embedded
-        run: npm rebuild sass-embedded
-
       # build
       - run: npm run build:ci
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'npm'
-      - name: Install npm@11.4.0 (global)
+      - name: Install npm@11.5.2 (global)
         run: |
-          npm i -g npm@11.4.0
+          npm i -g npm@11.5.2
           npm --version
       - name: setup
         run: npm ci

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,9 +22,6 @@ jobs:
       - name: setup
         run: npm ci
 
-      - name: rebuild sass-embedded
-        run: npm rebuild sass-embedded
-
       # build
       - run: npm run build:ci
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: setup
         run: npm ci
 
+      - name: rebuild sass-embedded
+        run: npm rebuild sass-embedded
+
       # build
       - run: npm run build:ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7329,6 +7329,54 @@
         "sass-embedded-win32-x64": "1.86.3"
       }
     },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.86.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.86.3.tgz",
+      "integrity": "sha512-EgLwV4ORm5Hr0DmIXo0Xw/vlzwLnfAiqD2jDXIglkBsc5czJmo4/IBdGXOP65TRnsgJEqvbU3aQhuawX5++x9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.86.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.86.3.tgz",
+      "integrity": "sha512-dfKhfrGPRNLWLC82vy/vQGmNKmAiKWpdFuWiePRtg/E95pqw+sCu6080Y6oQLfFu37Iq3MpnXiSpDuSo7UnPWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.86.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.86.3.tgz",
+      "integrity": "sha512-t8be9zJ5B82+og9bQmIQ83yMGYZMTMrlGA+uGWtYacmwg6w3093dk91Fx0YzNSZBp3Tk60qVYjCZnEIwy60x0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -10035,6 +10083,11 @@
         "svelte-check": "4.3.1",
         "svelte-sitemap": "2.7.1",
         "vite-bundle-analyzer": "0.23.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-darwin-arm64": "1.86.3",
+        "sass-embedded-darwin-x64": "1.86.3",
+        "sass-embedded-linux-x64": "1.86.3"
       }
     },
     "packages/web/node_modules/globals": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -51,5 +51,10 @@
     "svelte": "4.2.20",
     "svelte-i18next": "2.2.2"
   },
+  "optionalDependencies": {
+    "sass-embedded-linux-x64": "1.86.3",
+    "sass-embedded-darwin-arm64": "1.86.3",
+    "sass-embedded-darwin-x64": "1.86.3"
+  },
   "type": "module"
 }


### PR DESCRIPTION
CI 失敗（sass-embedded の実行ファイル未検出）を解消するため、GitHub Actions の npm を 11.5.2 に固定しました。

- 対象: ci-test / ci-lint / ci-build-web / ci-lighthouse / _google-app-scripts-deploy
- 目的: PR #768 の `engines.npm` / `packageManager` (= 11.5.2) と CI を整合させ、Vite ビルド時の `Embedded Dart Sass couldn't find the embedded compiler executable` を回避
- 影響: CI のみ（アプリ挙動は不変）

補足: Cloudflare Pages 側も npm を 11.5.2 に合わせる必要があります（Dashboard の Build 設定で `npx -y npm@11.5.2 ci` / `npx -y npm@11.5.2 run build:ci` を指定）。
