### PR TITLE
fix(seo): preserve redirect context and update docs

### DIFF
--- a/packages/github-pages/index.html
+++ b/packages/github-pages/index.html
@@ -7,10 +7,17 @@
     <meta name="description" content="ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール。部位ごとのパーツ固定や条件設定によるアセンブルを生成、およびアセンブルのステータスを確認可能。">
     
     <!-- SEO評価継承の鍵: canonical URL -->
-    <link rel="canonical" href="https://ac6-assemble-tool.philomagi.dev/">
-    
+    <link id="canonical-link" rel="canonical" href="https://ac6-assemble-tool.philomagi.dev/">
+
     <!-- 即座のリダイレクト -->
-    <meta http-equiv="refresh" content="0;url=https://ac6-assemble-tool.philomagi.dev/">
+    <meta id="redirect-meta" http-equiv="refresh">
+
+    <script>
+        const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`;
+        document.getElementById('canonical-link').setAttribute('href', redirectUrl);
+        document.getElementById('redirect-meta').setAttribute('content', `0;url=${redirectUrl}`);
+        window.location.replace(redirectUrl);
+    </script>
     
     <!-- Open Graph -->
     <meta property="og:title" content="AC6 ASSEMBLE TOOL | ARMORED CORE Ⅵ FIRES OF RUBICON">
@@ -102,9 +109,5 @@
         </div>
     </div>
 
-    <script>
-        // 即座のリダイレクト（評価継承を最大化）
-        window.location.replace('https://ac6-assemble-tool.philomagi.dev/');
-    </script>
 </body>
 </html>

--- a/packages/github-pages/index.html
+++ b/packages/github-pages/index.html
@@ -13,7 +13,8 @@
     <meta id="redirect-meta" http-equiv="refresh">
 
     <script>
-        const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`;
+        const path = window.location.pathname.replace(/^\/ac6_assemble_tool/, '');
+        const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${path}${window.location.search}${window.location.hash}`;
         document.getElementById('canonical-link').setAttribute('href', redirectUrl);
         document.getElementById('redirect-meta').setAttribute('content', `0;url=${redirectUrl}`);
         window.location.replace(redirectUrl);

--- a/packages/web/SEO_EVALUATION_PRESERVATION.md
+++ b/packages/web/SEO_EVALUATION_PRESERVATION.md
@@ -3,6 +3,7 @@
 ## 🚨 重要な懸念: SEO評価の消失リスク
 
 ### 問題
+
 - JavaScript Redirectは301リダイレクトと異なり、評価継承が不確実
 - 旧URLで築いた検索ランキング・被リンク評価を失う可能性
 - 完全に新サイトとして認識される危険性
@@ -10,11 +11,13 @@
 ## 🔍 Googleの JavaScript Redirect 処理
 
 ### 公式見解
+
 1. **認識する**: GooglebotはJavaScriptリダイレクトを検出可能
 2. **評価継承**: 適切な実装で一部評価を継承
 3. **条件**: 即座のリダイレクト + 明確なシグナルが必要
 
 ### 実際の評価継承率
+
 - **Server Redirect (301)**: 90-99% の評価継承
 - **JavaScript Redirect**: 70-85% の評価継承（実装による）
 - **評価消失リスク**: 15-30%
@@ -24,57 +27,83 @@
 ### 1. SEOシグナル強化版リダイレクトページ
 
 #### 改良版 `/index.html`
+
 ```html
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>AC6 ASSEMBLE TOOL | ARMORED CORE Ⅵ FIRES OF RUBICON</title>
-    <meta name="description" content="ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール。部位ごとのパーツ固定や条件設定によるアセンブルを生成、およびアセンブルのステータスを確認可能。">
-    
+    <meta
+      name="description"
+      content="ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール。部位ごとのパーツ固定や条件設定によるアセンブルを生成、およびアセンブルのステータスを確認可能。"
+    />
+
     <!-- 🔑 評価継承の鍵: canonical URL -->
-    <link rel="canonical" href="https://ac6-assemble-tool.philomagi.dev/">
-    
+    <link
+      id="canonical-link"
+      rel="canonical"
+      href="https://ac6-assemble-tool.philomagi.dev/"
+    />
+
     <!-- 移転シグナル -->
-    <meta http-equiv="refresh" content="0;url=https://ac6-assemble-tool.philomagi.dev/">
-    
-    <!-- 構造化データで移転を明示 -->
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "url": "https://tooppoo.github.io/ac6_assemble_tool/",
-      "mainEntity": {
-        "@type": "WebPage",
-        "url": "https://ac6-assemble-tool.philomagi.dev/",
-        "name": "AC6 ASSEMBLE TOOL",
-        "description": "ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール"
-      }
-    }
-    </script>
-    
-    <style>
-        body { font-family: sans-serif; text-align: center; padding: 20px; }
-        .notice { max-width: 600px; margin: 0 auto; }
-    </style>
-</head>
-<body>
-    <!-- 即座のリダイレクト（0秒） + ユーザー向け説明 -->
-    <div class="notice">
-        <h1>AC6 ASSEMBLE TOOL</h1>
-        <p>サイトは以下のURLに移転しました：</p>
-        <p><a href="https://ac6-assemble-tool.philomagi.dev/">https://ac6-assemble-tool.philomagi.dev/</a></p>
-    </div>
+    <meta id="redirect-meta" http-equiv="refresh" />
 
     <script>
-        // 即座のリダイレクト
-        window.location.replace('https://ac6-assemble-tool.philomagi.dev/');
+      const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`
+      document
+        .getElementById('canonical-link')
+        .setAttribute('href', redirectUrl)
+      document
+        .getElementById('redirect-meta')
+        .setAttribute('content', `0;url=${redirectUrl}`)
+      window.location.replace(redirectUrl)
     </script>
-</body>
+
+    <!-- 構造化データで移転を明示 -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "url": "https://tooppoo.github.io/ac6_assemble_tool/",
+        "mainEntity": {
+          "@type": "WebPage",
+          "url": "https://ac6-assemble-tool.philomagi.dev/",
+          "name": "AC6 ASSEMBLE TOOL",
+          "description": "ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール"
+        }
+      }
+    </script>
+
+    <style>
+      body {
+        font-family: sans-serif;
+        text-align: center;
+        padding: 20px;
+      }
+      .notice {
+        max-width: 600px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- 即座のリダイレクト（0秒） + ユーザー向け説明 -->
+    <div class="notice">
+      <h1>AC6 ASSEMBLE TOOL</h1>
+      <p>サイトは以下のURLに移転しました：</p>
+      <p>
+        <a href="https://ac6-assemble-tool.philomagi.dev/"
+          >https://ac6-assemble-tool.philomagi.dev/</a
+        >
+      </p>
+    </div>
+  </body>
 </html>
 ```
 
 ### 2. robots.txt の調整
+
 ```
 User-agent: *
 Allow: /
@@ -86,32 +115,38 @@ Sitemap: https://ac6-assemble-tool.philomagi.dev/sitemap.xml
 ## ⚖️ リスク評価とトレードオフ
 
 ### 🔴 高リスク戦略: 完全分離
+
 - **メリット**: 新サイトの完全独立、robots.txt等の恩恵最大
 - **デメリット**: SEO評価15-30%消失リスク
 
 ### 🟡 中リスク戦略: 評価継承優先JavaScript Redirect
+
 - **メリット**: 70-85%の評価継承期待
 - **デメリット**: HTTPS問題は未解決
 
 ### 🟢 低リスク戦略: 段階的移行（推奨）
 
 #### Phase 1: 評価継承優先リダイレクト
+
 1. 改良版JavaScript Redirectページを実装
 2. 3-6ヶ月間運用し、新URLの評価確立を待つ
 3. Google Search Consoleで効果測定
 
 #### Phase 2: 必要に応じて調整
+
 - 新URLの評価が十分確立されたら、robots.txtでnoindexに変更
 - または、評価継承が十分でない場合は戦略を再検討
 
 ## 📊 推奨アプローチ: 段階的評価継承戦略
 
 ### 実装優先順位
+
 1. **即座実装**: 改良版JavaScript Redirectページ
 2. **3ヶ月後**: Google Search Console で効果測定
 3. **6ヶ月後**: 必要に応じてrobotsディレクティブ調整
 
 ### 期待される結果
+
 - **評価継承**: 70-85%の確率で成功
 - **HTTPS問題**: JavaScriptリダイレクトでは解決されない（トレードオフ）
 - **ユーザー体験**: 維持

--- a/packages/web/SEO_EVALUATION_PRESERVATION.md
+++ b/packages/web/SEO_EVALUATION_PRESERVATION.md
@@ -50,7 +50,8 @@
     <meta id="redirect-meta" http-equiv="refresh" />
 
     <script>
-      const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`
+      const path = window.location.pathname.replace(/^\/ac6_assemble_tool/, '')
+      const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${path}${window.location.search}${window.location.hash}`
       document
         .getElementById('canonical-link')
         .setAttribute('href', redirectUrl)

--- a/packages/web/SEO_REDIRECT_IMPLEMENTATION.md
+++ b/packages/web/SEO_REDIRECT_IMPLEMENTATION.md
@@ -3,9 +3,11 @@
 ## ✅ 実装済み内容
 
 ### 1. GitHub Pages リダイレクトページ
+
 **ファイル**: `packages/github-pages/index.html`
 
 #### 主要機能
+
 - **即座のリダイレクト**: `window.location.replace()` で0秒リダイレクト
 - **Canonical URL**: `rel="canonical"` で新URLを明示
 - **構造化データ**: Schema.orgでサイト移転を明示
@@ -13,26 +15,43 @@
 - **UXデザイン**: ユーザーフレンドリーな移転案内
 
 #### SEO評価継承の仕組み
+
 ```html
 <!-- 評価継承の鍵 -->
-<link rel="canonical" href="https://ac6-assemble-tool.philomagi.dev/">
-<meta http-equiv="refresh" content="0;url=https://ac6-assemble-tool.philomagi.dev/">
+<link
+  id="canonical-link"
+  rel="canonical"
+  href="https://ac6-assemble-tool.philomagi.dev/"
+/>
+<meta id="redirect-meta" http-equiv="refresh" />
+
+<script>
+  const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`
+  document.getElementById('canonical-link').setAttribute('href', redirectUrl)
+  document
+    .getElementById('redirect-meta')
+    .setAttribute('content', `0;url=${redirectUrl}`)
+  window.location.replace(redirectUrl)
+</script>
 
 <!-- 構造化データで移転明示 -->
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "url": "https://tooppoo.github.io/ac6_assemble_tool/",
-  "mainEntity": {
-    "@type": "WebPage", 
-    "url": "https://ac6-assemble-tool.philomagi.dev/"
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "url": "https://tooppoo.github.io/ac6_assemble_tool/",
+    "mainEntity": {
+      "@type": "WebPage",
+      "url": "https://ac6-assemble-tool.philomagi.dev/",
+      "name": "AC6 ASSEMBLE TOOL",
+      "description": "ARMORED CORE Ⅵ FIRES OF RUBICON 用 非公式アセンブル支援ツール"
+    }
   }
-}
 </script>
 ```
 
 ### 2. robots.txt 評価継承設定
+
 **ファイル**: `packages/github-pages/robots.txt`
 
 ```
@@ -44,6 +63,7 @@ Sitemap: https://ac6-assemble-tool.philomagi.dev/sitemap.xml
 ```
 
 ### 3. GitHub Actions ワークフロー
+
 **ファイル**: `.github/workflows/github-pages-deploy.yml`
 
 - mainブランチプッシュ時の自動デプロイ
@@ -52,6 +72,7 @@ Sitemap: https://ac6-assemble-tool.philomagi.dev/sitemap.xml
 ## 🔄 動作フロー
 
 ### ユーザーアクセス時
+
 ```
 https://tooppoo.github.io/ac6_assemble_tool/
 ↓ (0秒で自動リダイレクト)
@@ -59,6 +80,7 @@ https://ac6-assemble-tool.philomagi.dev/
 ```
 
 ### Googleクローラーの処理
+
 ```
 1. 旧URL発見
 2. canonical URL検出 → https://ac6-assemble-tool.philomagi.dev/
@@ -69,14 +91,16 @@ https://ac6-assemble-tool.philomagi.dev/
 ## 📊 期待される効果
 
 ### SEO評価継承
+
 - **成功率**: 70-85%の評価継承期待
-- **継承要素**: 
+- **継承要素**:
   - 検索ランキング位置
   - 被リンク評価
   - ドメインオーソリティ
   - コンテンツ評価
 
 ### ユーザー体験
+
 - ✅ ブックマークからのアクセス維持
 - ✅ 外部サイトリンクからの流入維持
 - ✅ 瞬間的なリダイレクトでストレスフリー
@@ -84,11 +108,13 @@ https://ac6-assemble-tool.philomagi.dev/
 ## 🚀 次の手動作業
 
 ### GitHub Pages 設定
+
 1. GitHub リポジトリ → Settings → Pages
 2. Source → **GitHub Actions** を選択
 3. Custom domain 欄は **空のまま** にする
 
 ### 効果測定
+
 - **1週間後**: Google Search Console でクロール状況確認
 - **1ヶ月後**: 新URL のインデックス状況確認
 - **3ヶ月後**: 評価継承効果の最終判定
@@ -96,11 +122,13 @@ https://ac6-assemble-tool.philomagi.dev/
 ## ⚠️ 注意点
 
 ### HTTPリダイレクト問題について
+
 - この実装では **HTTPリダイレクト問題は解決されません**
 - トレードオフとしてSEO評価継承を優先
 - robots.txt修正効果と合わせて段階的改善を目指す
 
 ### モニタリング項目
+
 - 旧URL のクロール頻度変化
 - 新URL のインデックス登録状況
 - 検索ランキング位置の変動

--- a/packages/web/SEO_REDIRECT_IMPLEMENTATION.md
+++ b/packages/web/SEO_REDIRECT_IMPLEMENTATION.md
@@ -26,7 +26,8 @@
 <meta id="redirect-meta" http-equiv="refresh" />
 
 <script>
-  const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${window.location.pathname}${window.location.search}${window.location.hash}`
+  const path = window.location.pathname.replace(/^\/ac6_assemble_tool/, '')
+  const redirectUrl = `https://ac6-assemble-tool.philomagi.dev${path}${window.location.search}${window.location.hash}`
   document.getElementById('canonical-link').setAttribute('href', redirectUrl)
   document
     .getElementById('redirect-meta')


### PR DESCRIPTION
## Summary
- preserve path, query, and hash when redirecting from GitHub Pages
- move redirect script to `<head>` and align documentation
- document structured data with `name` and `description`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc046ba16c83218fcdbfb5de672fce