### PR TITLE
test: テスト品質改善 - アサーション統合、Parameterized/Property-based test導入

### DIFF
--- a/packages/core/spec-helper/property-generator.ts
+++ b/packages/core/spec-helper/property-generator.ts
@@ -109,23 +109,3 @@ export const genFilterApplyContext = () =>
       ),
     }),
   )
-
-const genPartIdForSlot = (slot: AssemblyKey, opt: { idMin: number, idMax: number }) => fc.integer({ min: opt.idMin, max: opt.idMax })
-  .map((v) => v.toString().padStart(3, '0'))
-  .map((id) => {
-    switch (slot) {
-      case 'core':
-        return `CR${id}`
-      case 'head':
-        return `HD${id}`
-      // 省略
-      default:
-        throw new Error(`Unsupported slot: ${slot}`)
-    }
-  })
-const genAssemblyKeyAndPartIdPair = (opt: { idMin: number, idMax: number }) => genAssemblyKeys().chain((slots) => fc.tuple(
-  ...slots.map((slot) => fc.tuple(
-    fc.constant(slot),
-    genPartIdForSlot(slot, opt),
-  ))
-))

--- a/packages/core/spec-helper/property-generator.ts
+++ b/packages/core/spec-helper/property-generator.ts
@@ -109,3 +109,49 @@ export const genFilterApplyContext = () =>
       ),
     }),
   )
+
+/**
+ * パーツID検索テスト用のジェネレータ
+ */
+
+// 正しいフォーマットのパーツIDを生成 (例: HD001, CR042, FCS001)
+export const genPartId = () =>
+  fc
+    .record({
+      prefix: fc.constantFrom('HD', 'CR', 'AR', 'LG', 'BS', 'FCS', 'GN', 'EXP', 'AU', 'BU'),
+      number: fc.integer({ min: 1, max: 999 }),
+    })
+    .map(({ prefix, number }) => `${prefix}${String(number).padStart(3, '0')}`)
+
+export const genPart = () =>
+  fc.record({
+    id: genPartId(),
+    name: fc.string({ minLength: 1, maxLength: 20 }),
+  })
+
+export const genParts = (constraints: ArrayConstraints = {}) =>
+  fc.array(genPart(), { minLength: 1, maxLength: 20, ...constraints })
+
+// パーツ配列と、その配列に確実に存在するパーツを生成
+export const genPartWithId = () =>
+  genParts().chain((parts) =>
+    fc.record({
+      parts: fc.constant(parts),
+      targetPart: fc.constantFrom(...parts),
+    }),
+  )
+
+// パーツ配列と検索ID（存在するかは不明）を生成
+export const genPartsAndSearchId = () =>
+  fc.record({
+    parts: genParts(),
+    searchId: genPartId(),
+  })
+
+// パーツ配列、検索ID、フォールバックを生成
+export const genPartsWithFallback = () =>
+  fc.record({
+    parts: genParts({ minLength: 0 }),
+    searchId: genPartId(),
+    fallback: genPart(),
+  })

--- a/packages/core/spec-helper/property-generator.ts
+++ b/packages/core/spec-helper/property-generator.ts
@@ -118,7 +118,18 @@ export const genFilterApplyContext = () =>
 export const genPartId = () =>
   fc
     .record({
-      prefix: fc.constantFrom('HD', 'CR', 'AR', 'LG', 'BS', 'FCS', 'GN', 'EXP', 'AU', 'BU'),
+      prefix: fc.constantFrom(
+        'HD',
+        'CR',
+        'AR',
+        'LG',
+        'BS',
+        'FCS',
+        'GN',
+        'EXP',
+        'AU',
+        'BU',
+      ),
       number: fc.integer({ min: 1, max: 999 }),
     })
     .map(({ prefix, number }) => `${prefix}${String(number).padStart(3, '0')}`)

--- a/packages/core/spec-helper/property-generator.ts
+++ b/packages/core/spec-helper/property-generator.ts
@@ -140,8 +140,16 @@ export const genPart = () =>
     name: fc.string({ minLength: 1, maxLength: 20 }),
   })
 
+// IDがユニークなパーツ配列を生成
 export const genParts = (constraints: ArrayConstraints = {}) =>
-  fc.array(genPart(), { minLength: 1, maxLength: 20, ...constraints })
+  fc
+    .uniqueArray(genPart(), {
+      minLength: 1,
+      maxLength: 20,
+      selector: (part) => part.id,
+      ...constraints,
+    })
+    .map((parts) => parts as Array<{ id: string; name: string }>)
 
 // パーツ配列と、その配列に確実に存在するパーツを生成
 export const genPartWithId = () =>

--- a/packages/core/spec/assembly/serialize/as-query-v2.spec.ts
+++ b/packages/core/spec/assembly/serialize/as-query-v2.spec.ts
@@ -16,140 +16,116 @@ import type { Head } from '@ac6_assemble_tool/parts/heads'
 import type { Legs } from '@ac6_assemble_tool/parts/legs'
 import { describe, it, expect } from 'vitest'
 
+// 共通テストデータ - describe外で定義
+const testAssemblyData: RawAssembly = {
+  rightArmUnit: {
+    id: 'AU001',
+    name: 'Test Arm Unit',
+  } as Partial<ArmUnit> as ArmUnit,
+  leftArmUnit: {
+    id: 'AU002',
+    name: 'Test Left Arm',
+  } as Partial<LeftArmUnit> as LeftArmUnit,
+  rightBackUnit: {
+    id: 'BU001',
+    name: 'Test Back Unit',
+  } as Partial<BackUnit> as BackUnit,
+  leftBackUnit: {
+    id: 'BU002',
+    name: 'Test Left Back',
+  } as Partial<LeftBackUnit> as LeftBackUnit,
+  head: { id: 'HD001', name: 'Test Head' } as Partial<Head> as Head,
+  core: { id: 'CR001', name: 'Test Core' } as Partial<Core> as Core,
+  arms: { id: 'AR001', name: 'Test Arms' } as Partial<Arms> as Arms,
+  legs: { id: 'LG001', name: 'Test Legs' } as Partial<Legs> as Legs,
+  booster: {
+    id: 'BS001',
+    name: 'Test Booster',
+  } as Partial<Booster> as Booster,
+  fcs: { id: 'FCS001', name: 'Test FCS' } as Partial<FCS> as FCS,
+  generator: {
+    id: 'GN001',
+    name: 'Test Generator',
+  } as Partial<Generator> as Generator,
+  expansion: {
+    id: 'EXP001',
+    name: 'Test Expansion',
+  } as Partial<Expansion> as Expansion,
+} as RawAssembly
+
 describe('v2形式URLシリアライザー', () => {
   describe('assemblyToSearchV2', () => {
-    it('v=2パラメータを含む', () => {
-      const assembly = createAssembly({
-        rightArmUnit: {
-          id: 'AU001',
-          name: 'Test Arm Unit',
-        } as Partial<ArmUnit> as ArmUnit,
-        leftArmUnit: {
-          id: 'AU002',
-          name: 'Test Left Arm',
-        } as Partial<LeftArmUnit> as LeftArmUnit,
-        rightBackUnit: {
-          id: 'BU001',
-          name: 'Test Back Unit',
-        } as Partial<BackUnit> as BackUnit,
-        leftBackUnit: {
-          id: 'BU002',
-          name: 'Test Left Back',
-        } as Partial<LeftBackUnit> as LeftBackUnit,
-        head: { id: 'HD001', name: 'Test Head' } as Partial<Head> as Head,
-        core: { id: 'CR001', name: 'Test Core' } as Partial<Core> as Core,
-        arms: { id: 'AR001', name: 'Test Arms' } as Partial<Arms> as Arms,
-        legs: { id: 'LG001', name: 'Test Legs' } as Partial<Legs> as Legs,
-        booster: {
-          id: 'BS001',
-          name: 'Test Booster',
-        } as Partial<Booster> as Booster,
-        fcs: { id: 'FCS001', name: 'Test FCS' } as Partial<FCS> as FCS,
-        generator: {
-          id: 'GN001',
-          name: 'Test Generator',
-        } as Partial<Generator> as Generator,
-        expansion: {
-          id: 'EXP001',
-          name: 'Test Expansion',
-        } as Partial<Expansion> as Expansion,
-      } as RawAssembly)
-
+    it('v=2パラメータと全てのパーツIDをクエリパラメータに含む', () => {
+      const assembly = createAssembly(testAssemblyData)
       const result = assemblyToSearchV2(assembly)
 
-      expect(result.get('v')).toBe('2')
-    })
-
-    it('各部位のパーツIDをクエリパラメータに含む', () => {
-      const assembly = createAssembly({
-        rightArmUnit: {
-          id: 'AU001',
-          name: 'Test',
-        } as Partial<ArmUnit> as ArmUnit,
-        leftArmUnit: {
-          id: 'AU002',
-          name: 'Test',
-        } as Partial<LeftArmUnit> as LeftArmUnit,
-        rightBackUnit: {
-          id: 'BU001',
-          name: 'Test',
-        } as Partial<BackUnit> as BackUnit,
-        leftBackUnit: {
-          id: 'BU002',
-          name: 'Test',
-        } as Partial<LeftBackUnit> as LeftBackUnit,
-        head: { id: 'HD001', name: 'Test' } as Partial<Head> as Head,
-        core: { id: 'CR001', name: 'Test' } as Partial<Core> as Core,
-        arms: { id: 'AR001', name: 'Test' } as Partial<Arms> as Arms,
-        legs: { id: 'LG001', name: 'Test' } as Partial<Legs> as Legs,
-        booster: { id: 'BS001', name: 'Test' } as Partial<Booster> as Booster,
-        fcs: { id: 'FCS001', name: 'Test' } as Partial<FCS> as FCS,
-        generator: {
-          id: 'GN001',
-          name: 'Test',
-        } as Partial<Generator> as Generator,
-        expansion: {
-          id: 'EXP001',
-          name: 'Test',
-        } as Partial<Expansion> as Expansion,
-      } as RawAssembly)
-
-      const result = assemblyToSearchV2(assembly)
-
-      expect(result.get('rau')).toBe('AU001')
-      expect(result.get('lau')).toBe('AU002')
-      expect(result.get('rbu')).toBe('BU001')
-      expect(result.get('lbu')).toBe('BU002')
-      expect(result.get('h')).toBe('HD001')
-      expect(result.get('c')).toBe('CR001')
-      expect(result.get('a')).toBe('AR001')
-      expect(result.get('l')).toBe('LG001')
-      expect(result.get('b')).toBe('BS001')
-      expect(result.get('f')).toBe('FCS001')
-      expect(result.get('g')).toBe('GN001')
-      expect(result.get('e')).toBe('EXP001')
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        version: result.get('v'),
+        rightArmUnit: result.get('rau'),
+        leftArmUnit: result.get('lau'),
+        rightBackUnit: result.get('rbu'),
+        leftBackUnit: result.get('lbu'),
+        head: result.get('h'),
+        core: result.get('c'),
+        arms: result.get('a'),
+        legs: result.get('l'),
+        booster: result.get('b'),
+        fcs: result.get('f'),
+        generator: result.get('g'),
+        expansion: result.get('e'),
+      }).toEqual({
+        version: '2',
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU002',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU002',
+        head: 'HD001',
+        core: 'CR001',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
 
     it('URL文字列を生成できる', () => {
-      const assembly = createAssembly({
-        rightArmUnit: {
-          id: 'AU001',
-          name: 'Test',
-        } as Partial<ArmUnit> as ArmUnit,
-        leftArmUnit: {
-          id: 'AU001',
-          name: 'Test',
-        } as Partial<ArmUnit> as ArmUnit,
-        rightBackUnit: {
-          id: 'BU001',
-          name: 'Test',
-        } as Partial<BackUnit> as BackUnit,
-        leftBackUnit: {
-          id: 'BU001',
-          name: 'Test',
-        } as Partial<BackUnit> as BackUnit,
-        head: { id: 'HD001', name: 'Test' } as Partial<Head> as Head,
-        core: { id: 'CR001', name: 'Test' } as Partial<Core> as Core,
-        arms: { id: 'AR001', name: 'Test' } as Partial<Arms> as Arms,
-        legs: { id: 'LG001', name: 'Test' } as Partial<Legs> as Legs,
-        booster: { id: 'BS001', name: 'Test' } as Partial<Booster> as Booster,
-        fcs: { id: 'FCS001', name: 'Test' } as Partial<FCS> as FCS,
-        generator: {
-          id: 'GN001',
-          name: 'Test',
-        } as Partial<Generator> as Generator,
-        expansion: {
-          id: 'EXP001',
-          name: 'Test',
-        } as Partial<Expansion> as Expansion,
-      } as RawAssembly)
-
+      const assembly = createAssembly(testAssemblyData)
       const result = assemblyToSearchV2(assembly)
       const urlString = result.toString()
 
-      expect(urlString).toContain('v=2')
-      expect(urlString).toContain('h=HD001')
-      expect(urlString).toContain('c=CR001')
+      // 必須パラメータが含まれることを確認
+      expect({
+        hasVersion: urlString.includes('v=2'),
+        hasHead: urlString.includes('h=HD001'),
+        hasCore: urlString.includes('c=CR001'),
+        hasArms: urlString.includes('a=AR001'),
+        hasLegs: urlString.includes('l=LG001'),
+        hasBooster: urlString.includes('b=BS001'),
+        hasFcs: urlString.includes('f=FCS001'),
+        hasGenerator: urlString.includes('g=GN001'),
+        hasExpansion: urlString.includes('e=EXP001'),
+        hasRightArmUnit: urlString.includes('rau=AU001'),
+        hasLeftArmUnit: urlString.includes('lau=AU002'),
+        hasRightBackUnit: urlString.includes('rbu=BU001'),
+        hasLeftBackUnit: urlString.includes('lbu=BU002'),
+      }).toEqual({
+        hasVersion: true,
+        hasHead: true,
+        hasCore: true,
+        hasArms: true,
+        hasLegs: true,
+        hasBooster: true,
+        hasFcs: true,
+        hasGenerator: true,
+        hasExpansion: true,
+        hasRightArmUnit: true,
+        hasLeftArmUnit: true,
+        hasRightBackUnit: true,
+        hasLeftBackUnit: true,
+      })
     })
   })
 })

--- a/packages/core/spec/assembly/serialize/convert-v1-to-v2.spec.ts
+++ b/packages/core/spec/assembly/serialize/convert-v1-to-v2.spec.ts
@@ -16,64 +16,65 @@ import type { Legs } from '@ac6_assemble_tool/parts/legs'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 import { describe, it, expect } from 'vitest'
 
-describe('v1→v2変換', () => {
-  const mockCandidates: Candidates = {
-    rightArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
-    ],
-    leftArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      {
-        id: 'AU003',
-        name: 'Left Arm Unit 3',
-      } as Partial<LeftArmUnit> as LeftArmUnit,
-    ],
-    rightBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
-    ],
-    leftBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      {
-        id: 'BU003',
-        name: 'Left Back Unit 3',
-      } as Partial<LeftBackUnit> as LeftBackUnit,
-    ],
-    head: [
-      { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
-      { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
-    ],
-    core: [
-      { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
-      { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
-    ],
-    arms: [
-      { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
-      { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
-    ],
-    legs: [
-      { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
-      { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
-    ],
-    booster: [
-      { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
-      { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
-    ],
-    fcs: [
-      { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
-      { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
-    ],
-    generator: [
-      { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
-      { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
-    ],
-    expansion: [
-      { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
-      { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
-    ],
-  }
+// 共通テストデータ - describe外で定義
+const mockCandidates: Candidates = {
+  rightArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
+  ],
+  leftArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    {
+      id: 'AU003',
+      name: 'Left Arm Unit 3',
+    } as Partial<LeftArmUnit> as LeftArmUnit,
+  ],
+  rightBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
+  ],
+  leftBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    {
+      id: 'BU003',
+      name: 'Left Back Unit 3',
+    } as Partial<LeftBackUnit> as LeftBackUnit,
+  ],
+  head: [
+    { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
+    { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
+  ],
+  core: [
+    { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
+    { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
+  ],
+  arms: [
+    { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
+    { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
+  ],
+  legs: [
+    { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
+    { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
+  ],
+  booster: [
+    { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
+    { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
+  ],
+  fcs: [
+    { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
+    { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
+  ],
+  generator: [
+    { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
+    { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
+  ],
+  expansion: [
+    { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
+    { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
+  ],
+}
 
+describe('v1→v2変換', () => {
   describe('convertV1ToV2', () => {
     it('v1形式URLをv2形式に変換できる', () => {
       const v1Params = new URLSearchParams({
@@ -93,19 +94,36 @@ describe('v1→v2変換', () => {
 
       const result = convertV1ToV2(v1Params, mockCandidates)
 
-      expect(result.get('v')).toBe('2')
-      expect(result.get('rau')).toBe('AU001')
-      expect(result.get('lau')).toBe('AU003')
-      expect(result.get('rbu')).toBe('BU001')
-      expect(result.get('lbu')).toBe('BU003')
-      expect(result.get('h')).toBe('HD001')
-      expect(result.get('c')).toBe('CR001')
-      expect(result.get('a')).toBe('AR001')
-      expect(result.get('l')).toBe('LG001')
-      expect(result.get('b')).toBe('BS001')
-      expect(result.get('f')).toBe('FCS001')
-      expect(result.get('g')).toBe('GN001')
-      expect(result.get('e')).toBe('EXP001')
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        version: result.get('v'),
+        rightArmUnit: result.get('rau'),
+        leftArmUnit: result.get('lau'),
+        rightBackUnit: result.get('rbu'),
+        leftBackUnit: result.get('lbu'),
+        head: result.get('h'),
+        core: result.get('c'),
+        arms: result.get('a'),
+        legs: result.get('l'),
+        booster: result.get('b'),
+        fcs: result.get('f'),
+        generator: result.get('g'),
+        expansion: result.get('e'),
+      }).toEqual({
+        version: '2',
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU003',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU003',
+        head: 'HD001',
+        core: 'CR001',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
 
     it('インデックスが範囲外の場合は配列の最初の要素を使用', () => {
@@ -126,7 +144,6 @@ describe('v1→v2変換', () => {
 
       const result = convertV1ToV2(v1Params, mockCandidates)
 
-      // 範囲外のインデックスは配列の最初の要素にフォールバック
       expect(result.get('h')).toBe('HD001')
     })
 

--- a/packages/core/spec/assembly/serialize/deserialize-assembly.spec.ts
+++ b/packages/core/spec/assembly/serialize/deserialize-assembly.spec.ts
@@ -16,64 +16,65 @@ import type { Legs } from '@ac6_assemble_tool/parts/legs'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 import { describe, it, expect } from 'vitest'
 
-describe('機体構成デシリアライザー統合', () => {
-  const mockCandidates: Candidates = {
-    rightArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
-    ],
-    leftArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      {
-        id: 'AU003',
-        name: 'Left Arm Unit 3',
-      } as Partial<LeftArmUnit> as LeftArmUnit,
-    ],
-    rightBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
-    ],
-    leftBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      {
-        id: 'BU003',
-        name: 'Left Back Unit 3',
-      } as Partial<LeftBackUnit> as LeftBackUnit,
-    ],
-    head: [
-      { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
-      { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
-    ],
-    core: [
-      { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
-      { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
-    ],
-    arms: [
-      { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
-      { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
-    ],
-    legs: [
-      { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
-      { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
-    ],
-    booster: [
-      { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
-      { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
-    ],
-    fcs: [
-      { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
-      { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
-    ],
-    generator: [
-      { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
-      { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
-    ],
-    expansion: [
-      { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
-      { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
-    ],
-  }
+// 共通テストデータ - describe外で定義
+const mockCandidates: Candidates = {
+  rightArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
+  ],
+  leftArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    {
+      id: 'AU003',
+      name: 'Left Arm Unit 3',
+    } as Partial<LeftArmUnit> as LeftArmUnit,
+  ],
+  rightBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
+  ],
+  leftBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    {
+      id: 'BU003',
+      name: 'Left Back Unit 3',
+    } as Partial<LeftBackUnit> as LeftBackUnit,
+  ],
+  head: [
+    { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
+    { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
+  ],
+  core: [
+    { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
+    { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
+  ],
+  arms: [
+    { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
+    { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
+  ],
+  legs: [
+    { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
+    { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
+  ],
+  booster: [
+    { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
+    { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
+  ],
+  fcs: [
+    { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
+    { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
+  ],
+  generator: [
+    { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
+    { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
+  ],
+  expansion: [
+    { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
+    { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
+  ],
+}
 
+describe('機体構成デシリアライザー統合', () => {
   describe('deserializeAssembly', () => {
     it('v2形式URLから機体構成を復元できる', () => {
       const params = new URLSearchParams({
@@ -94,18 +95,34 @@ describe('機体構成デシリアライザー統合', () => {
 
       const result = deserializeAssembly(params, mockCandidates)
 
-      expect(result.rightArmUnit.id).toBe('AU001')
-      expect(result.leftArmUnit.id).toBe('AU003')
-      expect(result.rightBackUnit.id).toBe('BU001')
-      expect(result.leftBackUnit.id).toBe('BU003')
-      expect(result.head.id).toBe('HD001')
-      expect(result.core.id).toBe('CR001')
-      expect(result.arms.id).toBe('AR001')
-      expect(result.legs.id).toBe('LG001')
-      expect(result.booster.id).toBe('BS001')
-      expect(result.fcs.id).toBe('FCS001')
-      expect(result.generator.id).toBe('GN001')
-      expect(result.expansion.id).toBe('EXP001')
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        rightArmUnit: result.rightArmUnit.id,
+        leftArmUnit: result.leftArmUnit.id,
+        rightBackUnit: result.rightBackUnit.id,
+        leftBackUnit: result.leftBackUnit.id,
+        head: result.head.id,
+        core: result.core.id,
+        arms: result.arms.id,
+        legs: result.legs.id,
+        booster: result.booster.id,
+        fcs: result.fcs.id,
+        generator: result.generator.id,
+        expansion: result.expansion.id,
+      }).toEqual({
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU003',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU003',
+        head: 'HD001',
+        core: 'CR001',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
 
     it('v1形式URLを自動的にv2形式に変換して機体構成を復元できる', () => {
@@ -126,18 +143,33 @@ describe('機体構成デシリアライザー統合', () => {
 
       const result = deserializeAssembly(v1Params, mockCandidates)
 
-      expect(result.rightArmUnit.id).toBe('AU001')
-      expect(result.leftArmUnit.id).toBe('AU003')
-      expect(result.rightBackUnit.id).toBe('BU001')
-      expect(result.leftBackUnit.id).toBe('BU003')
-      expect(result.head.id).toBe('HD001')
-      expect(result.core.id).toBe('CR002')
-      expect(result.arms.id).toBe('AR001')
-      expect(result.legs.id).toBe('LG001')
-      expect(result.booster.id).toBe('BS001')
-      expect(result.fcs.id).toBe('FCS001')
-      expect(result.generator.id).toBe('GN001')
-      expect(result.expansion.id).toBe('EXP001')
+      expect({
+        rightArmUnit: result.rightArmUnit.id,
+        leftArmUnit: result.leftArmUnit.id,
+        rightBackUnit: result.rightBackUnit.id,
+        leftBackUnit: result.leftBackUnit.id,
+        head: result.head.id,
+        core: result.core.id,
+        arms: result.arms.id,
+        legs: result.legs.id,
+        booster: result.booster.id,
+        fcs: result.fcs.id,
+        generator: result.generator.id,
+        expansion: result.expansion.id,
+      }).toEqual({
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU003',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU003',
+        head: 'HD001',
+        core: 'CR002',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
 
     it('空のURLSearchParamsの場合は各配列の最初の要素を使用', () => {
@@ -145,10 +177,33 @@ describe('機体構成デシリアライザー統合', () => {
 
       const result = deserializeAssembly(params, mockCandidates)
 
-      expect(result.head.id).toBe('HD001')
-      expect(result.core.id).toBe('CR001')
-      expect(result.arms.id).toBe('AR001')
-      expect(result.legs.id).toBe('LG001')
+      expect({
+        rightArmUnit: result.rightArmUnit.id,
+        leftArmUnit: result.leftArmUnit.id,
+        rightBackUnit: result.rightBackUnit.id,
+        leftBackUnit: result.leftBackUnit.id,
+        head: result.head.id,
+        core: result.core.id,
+        arms: result.arms.id,
+        legs: result.legs.id,
+        booster: result.booster.id,
+        fcs: result.fcs.id,
+        generator: result.generator.id,
+        expansion: result.expansion.id,
+      }).toEqual({
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU001',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU001',
+        head: 'HD001',
+        core: 'CR001',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
   })
 })

--- a/packages/core/spec/assembly/serialize/search-to-assembly-v2.spec.ts
+++ b/packages/core/spec/assembly/serialize/search-to-assembly-v2.spec.ts
@@ -16,64 +16,65 @@ import type { Legs } from '@ac6_assemble_tool/parts/legs'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 import { describe, it, expect } from 'vitest'
 
-describe('v2形式URLデシリアライザー', () => {
-  const mockCandidates: Candidates = {
-    rightArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
-    ],
-    leftArmUnit: [
-      { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
-      {
-        id: 'AU003',
-        name: 'Left Arm Unit 3',
-      } as Partial<LeftArmUnit> as LeftArmUnit,
-    ],
-    rightBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
-    ],
-    leftBackUnit: [
-      { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
-      {
-        id: 'BU003',
-        name: 'Left Back Unit 3',
-      } as Partial<LeftBackUnit> as LeftBackUnit,
-    ],
-    head: [
-      { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
-      { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
-    ],
-    core: [
-      { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
-      { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
-    ],
-    arms: [
-      { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
-      { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
-    ],
-    legs: [
-      { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
-      { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
-    ],
-    booster: [
-      { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
-      { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
-    ],
-    fcs: [
-      { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
-      { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
-    ],
-    generator: [
-      { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
-      { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
-    ],
-    expansion: [
-      { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
-      { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
-    ],
-  }
+// 共通テストデータ - describe外で定義
+const mockCandidates: Candidates = {
+  rightArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    { id: 'AU002', name: 'Arm Unit 2' } as Partial<ArmUnit> as ArmUnit,
+  ],
+  leftArmUnit: [
+    { id: 'AU001', name: 'Arm Unit 1' } as Partial<ArmUnit> as ArmUnit,
+    {
+      id: 'AU003',
+      name: 'Left Arm Unit 3',
+    } as Partial<LeftArmUnit> as LeftArmUnit,
+  ],
+  rightBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    { id: 'BU002', name: 'Back Unit 2' } as Partial<BackUnit> as BackUnit,
+  ],
+  leftBackUnit: [
+    { id: 'BU001', name: 'Back Unit 1' } as Partial<BackUnit> as BackUnit,
+    {
+      id: 'BU003',
+      name: 'Left Back Unit 3',
+    } as Partial<LeftBackUnit> as LeftBackUnit,
+  ],
+  head: [
+    { id: 'HD001', name: 'Head 1' } as Partial<Head> as Head,
+    { id: 'HD002', name: 'Head 2' } as Partial<Head> as Head,
+  ],
+  core: [
+    { id: 'CR001', name: 'Core 1' } as Partial<Core> as Core,
+    { id: 'CR002', name: 'Core 2' } as Partial<Core> as Core,
+  ],
+  arms: [
+    { id: 'AR001', name: 'Arms 1' } as Partial<Arms> as Arms,
+    { id: 'AR002', name: 'Arms 2' } as Partial<Arms> as Arms,
+  ],
+  legs: [
+    { id: 'LG001', name: 'Legs 1' } as Partial<Legs> as Legs,
+    { id: 'LG002', name: 'Legs 2' } as Partial<Legs> as Legs,
+  ],
+  booster: [
+    { id: 'BS001', name: 'Booster 1' } as Partial<Booster> as Booster,
+    { id: 'BS002', name: 'Booster 2' } as Partial<Booster> as Booster,
+  ],
+  fcs: [
+    { id: 'FCS001', name: 'FCS 1' } as Partial<FCS> as FCS,
+    { id: 'FCS002', name: 'FCS 2' } as Partial<FCS> as FCS,
+  ],
+  generator: [
+    { id: 'GN001', name: 'Generator 1' } as Partial<Generator> as Generator,
+    { id: 'GN002', name: 'Generator 2' } as Partial<Generator> as Generator,
+  ],
+  expansion: [
+    { id: 'EXP001', name: 'Expansion 1' } as Partial<Expansion> as Expansion,
+    { id: 'EXP002', name: 'Expansion 2' } as Partial<Expansion> as Expansion,
+  ],
+}
 
+describe('v2形式URLデシリアライザー', () => {
   describe('searchToAssemblyV2', () => {
     it('v2形式URLから機体構成を復元できる', () => {
       const params = new URLSearchParams({
@@ -94,18 +95,34 @@ describe('v2形式URLデシリアライザー', () => {
 
       const result = searchToAssemblyV2(params, mockCandidates)
 
-      expect(result.rightArmUnit.id).toBe('AU001')
-      expect(result.leftArmUnit.id).toBe('AU003')
-      expect(result.rightBackUnit.id).toBe('BU001')
-      expect(result.leftBackUnit.id).toBe('BU003')
-      expect(result.head.id).toBe('HD001')
-      expect(result.core.id).toBe('CR001')
-      expect(result.arms.id).toBe('AR001')
-      expect(result.legs.id).toBe('LG001')
-      expect(result.booster.id).toBe('BS001')
-      expect(result.fcs.id).toBe('FCS001')
-      expect(result.generator.id).toBe('GN001')
-      expect(result.expansion.id).toBe('EXP001')
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        rightArmUnit: result.rightArmUnit.id,
+        leftArmUnit: result.leftArmUnit.id,
+        rightBackUnit: result.rightBackUnit.id,
+        leftBackUnit: result.leftBackUnit.id,
+        head: result.head.id,
+        core: result.core.id,
+        arms: result.arms.id,
+        legs: result.legs.id,
+        booster: result.booster.id,
+        fcs: result.fcs.id,
+        generator: result.generator.id,
+        expansion: result.expansion.id,
+      }).toEqual({
+        rightArmUnit: 'AU001',
+        leftArmUnit: 'AU003',
+        rightBackUnit: 'BU001',
+        leftBackUnit: 'BU003',
+        head: 'HD001',
+        core: 'CR001',
+        arms: 'AR001',
+        legs: 'LG001',
+        booster: 'BS001',
+        fcs: 'FCS001',
+        generator: 'GN001',
+        expansion: 'EXP001',
+      })
     })
 
     it('存在しないIDの場合は配列の最初の要素をフォールバックとして使用', () => {
@@ -127,7 +144,6 @@ describe('v2形式URLデシリアライザー', () => {
 
       const result = searchToAssemblyV2(params, mockCandidates)
 
-      // 存在しないIDの場合、配列の最初の要素がフォールバック
       expect(result.head.id).toBe('HD001')
     })
 

--- a/packages/core/spec/assembly/serialize/url-sharing-flow.spec.ts
+++ b/packages/core/spec/assembly/serialize/url-sharing-flow.spec.ts
@@ -33,27 +33,34 @@ describe('URL共有フロー統合テスト', () => {
         deserializeAssembly(urlParams, candidates),
       )
 
-      // 全部位が正しく復元されていることを確認
-      expect(restoredAssembly.rightArmUnit.id).toBe(
-        originalAssembly.rightArmUnit.id,
-      )
-      expect(restoredAssembly.leftArmUnit.id).toBe(
-        originalAssembly.leftArmUnit.id,
-      )
-      expect(restoredAssembly.rightBackUnit.id).toBe(
-        originalAssembly.rightBackUnit.id,
-      )
-      expect(restoredAssembly.leftBackUnit.id).toBe(
-        originalAssembly.leftBackUnit.id,
-      )
-      expect(restoredAssembly.head.id).toBe(originalAssembly.head.id)
-      expect(restoredAssembly.core.id).toBe(originalAssembly.core.id)
-      expect(restoredAssembly.arms.id).toBe(originalAssembly.arms.id)
-      expect(restoredAssembly.legs.id).toBe(originalAssembly.legs.id)
-      expect(restoredAssembly.booster.id).toBe(originalAssembly.booster.id)
-      expect(restoredAssembly.fcs.id).toBe(originalAssembly.fcs.id)
-      expect(restoredAssembly.generator.id).toBe(originalAssembly.generator.id)
-      expect(restoredAssembly.expansion.id).toBe(originalAssembly.expansion.id)
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        rightArmUnit: restoredAssembly.rightArmUnit.id,
+        leftArmUnit: restoredAssembly.leftArmUnit.id,
+        rightBackUnit: restoredAssembly.rightBackUnit.id,
+        leftBackUnit: restoredAssembly.leftBackUnit.id,
+        head: restoredAssembly.head.id,
+        core: restoredAssembly.core.id,
+        arms: restoredAssembly.arms.id,
+        legs: restoredAssembly.legs.id,
+        booster: restoredAssembly.booster.id,
+        fcs: restoredAssembly.fcs.id,
+        generator: restoredAssembly.generator.id,
+        expansion: restoredAssembly.expansion.id,
+      }).toEqual({
+        rightArmUnit: originalAssembly.rightArmUnit.id,
+        leftArmUnit: originalAssembly.leftArmUnit.id,
+        rightBackUnit: originalAssembly.rightBackUnit.id,
+        leftBackUnit: originalAssembly.leftBackUnit.id,
+        head: originalAssembly.head.id,
+        core: originalAssembly.core.id,
+        arms: originalAssembly.arms.id,
+        legs: originalAssembly.legs.id,
+        booster: originalAssembly.booster.id,
+        fcs: originalAssembly.fcs.id,
+        generator: originalAssembly.generator.id,
+        expansion: originalAssembly.expansion.id,
+      })
     })
 
     it('URL長がブラウザ制限内に収まる', () => {
@@ -110,11 +117,18 @@ describe('URL共有フロー統合テスト', () => {
       const expectedHead = candidates.head[8]
       const expectedCore = candidates.core[4]
 
-      // 正しく復元されていることを確認
-      expect(restoredAssembly.rightArmUnit.id).toBe(expectedRightArmUnit.id)
-      expect(restoredAssembly.leftArmUnit.id).toBe(expectedLeftArmUnit.id)
-      expect(restoredAssembly.head.id).toBe(expectedHead.id)
-      expect(restoredAssembly.core.id).toBe(expectedCore.id)
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        rightArmUnit: restoredAssembly.rightArmUnit.id,
+        leftArmUnit: restoredAssembly.leftArmUnit.id,
+        head: restoredAssembly.head.id,
+        core: restoredAssembly.core.id,
+      }).toEqual({
+        rightArmUnit: expectedRightArmUnit.id,
+        leftArmUnit: expectedLeftArmUnit.id,
+        head: expectedHead.id,
+        core: expectedCore.id,
+      })
     })
 
     it('v1→v2変換後のURLがv2形式になる', () => {
@@ -135,12 +149,16 @@ describe('URL共有フロー統合テスト', () => {
 
       const v2Params = convertV1ToV2(v1Params, candidates)
 
-      // v=2パラメータが含まれることを確認
-      expect(v2Params.get('v')).toBe('2')
-
-      // IDベースのパラメータになっていることを確認（数字だけでなくアルファベットを含む）
-      expect(v2Params.get('h')).toMatch(/^[A-Z]+\d+$/)
-      expect(v2Params.get('c')).toMatch(/^[A-Z]+\d+$/)
+      // v2形式の各パラメータを確認
+      expect({
+        version: v2Params.get('v'),
+        headIdFormat: v2Params.get('h')?.match(/^[A-Z]+\d+$/) !== null,
+        coreIdFormat: v2Params.get('c')?.match(/^[A-Z]+\d+$/) !== null,
+      }).toEqual({
+        version: '2',
+        headIdFormat: true,
+        coreIdFormat: true,
+      })
     })
   })
 
@@ -166,9 +184,14 @@ describe('URL共有フロー統合テスト', () => {
         deserializeAssembly(invalidParams, candidates),
       )
 
-      // 存在しないIDの場合、配列の最初の要素が使用される
-      expect(restoredAssembly.head.id).toBe(candidates.head[0].id)
-      expect(restoredAssembly.core.id).toBe('CR001')
+      // 存在しないIDと正常なIDの結果を確認
+      expect({
+        head: restoredAssembly.head.id,
+        core: restoredAssembly.core.id,
+      }).toEqual({
+        head: candidates.head[0].id,
+        core: 'CR001',
+      })
     })
 
     it('パラメータが欠けている場合は配列の最初の要素を使用', () => {
@@ -192,8 +215,13 @@ describe('URL共有フロー統合テスト', () => {
         deserializeAssembly(incompleteParams, candidates),
       )
 
-      expect(restoredAssembly.head.id).toBe(candidates.head[0].id)
-      expect(restoredAssembly.core.id).toBe('CR002')
+      expect({
+        head: restoredAssembly.head.id,
+        core: restoredAssembly.core.id,
+      }).toEqual({
+        head: candidates.head[0].id,
+        core: 'CR002',
+      })
     })
   })
 })

--- a/packages/core/spec/assembly/store/repository/storage-flow.spec.ts
+++ b/packages/core/spec/assembly/store/repository/storage-flow.spec.ts
@@ -7,7 +7,7 @@ import { IndexedDbRepository } from '#core/assembly/store/repository/indexed-db/
 
 import { candidates } from '@ac6_assemble_tool/parts/versions/v1.06.1'
 import { ulid } from 'ulid'
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 
 describe('IndexedDBストレージフロー統合テスト', () => {
   const repository = new IndexedDbRepository(candidates)

--- a/packages/core/spec/assembly/store/repository/storage-flow.spec.ts
+++ b/packages/core/spec/assembly/store/repository/storage-flow.spec.ts
@@ -48,21 +48,40 @@ describe('IndexedDBストレージフロー統合テスト', () => {
       // 読み込み
       const loaded = await repository.findById(testId, candidates)
 
-      expect(loaded).not.toBeNull()
-      expect(loaded?.name).toBe('Test Assembly v2')
-      expect(loaded?.description).toBe('v2形式テスト')
-
-      // 全部位が正しく復元されている
-      expect(loaded?.assembly.rightArmUnit.id).toBe(assembly.rightArmUnit.id)
-      expect(loaded?.assembly.leftArmUnit.id).toBe(assembly.leftArmUnit.id)
-      expect(loaded?.assembly.head.id).toBe(assembly.head.id)
-      expect(loaded?.assembly.core.id).toBe(assembly.core.id)
-      expect(loaded?.assembly.arms.id).toBe(assembly.arms.id)
-      expect(loaded?.assembly.legs.id).toBe(assembly.legs.id)
-      expect(loaded?.assembly.booster.id).toBe(assembly.booster.id)
-      expect(loaded?.assembly.fcs.id).toBe(assembly.fcs.id)
-      expect(loaded?.assembly.generator.id).toBe(assembly.generator.id)
-      expect(loaded?.assembly.expansion.id).toBe(assembly.expansion.id)
+      // 複数のexpectを1つにまとめて、全ての不一致を一度に確認
+      expect({
+        exists: loaded !== null,
+        name: loaded?.name,
+        description: loaded?.description,
+        rightArmUnit: loaded?.assembly.rightArmUnit.id,
+        leftArmUnit: loaded?.assembly.leftArmUnit.id,
+        rightBackUnit: loaded?.assembly.rightBackUnit.id,
+        leftBackUnit: loaded?.assembly.leftBackUnit.id,
+        head: loaded?.assembly.head.id,
+        core: loaded?.assembly.core.id,
+        arms: loaded?.assembly.arms.id,
+        legs: loaded?.assembly.legs.id,
+        booster: loaded?.assembly.booster.id,
+        fcs: loaded?.assembly.fcs.id,
+        generator: loaded?.assembly.generator.id,
+        expansion: loaded?.assembly.expansion.id,
+      }).toEqual({
+        exists: true,
+        name: 'Test Assembly v2',
+        description: 'v2形式テスト',
+        rightArmUnit: assembly.rightArmUnit.id,
+        leftArmUnit: assembly.leftArmUnit.id,
+        rightBackUnit: assembly.rightBackUnit.id,
+        leftBackUnit: assembly.leftBackUnit.id,
+        head: assembly.head.id,
+        core: assembly.core.id,
+        arms: assembly.arms.id,
+        legs: assembly.legs.id,
+        booster: assembly.booster.id,
+        fcs: assembly.fcs.id,
+        generator: assembly.generator.id,
+        expansion: assembly.expansion.id,
+      })
     }, 15000)
 
     it('複数の機体構成を保存し、全て読み込める', async () => {
@@ -130,10 +149,17 @@ describe('IndexedDBストレージフロー統合テスト', () => {
 
       const all = await repository.all(candidates)
 
-      expect(all).toHaveLength(3)
-      expect(all[0].name).toBe('Assembly 1')
-      expect(all[1].name).toBe('Assembly 2')
-      expect(all[2].name).toBe('Assembly 3')
+      expect({
+        count: all.length,
+        name1: all[0]?.name,
+        name2: all[1]?.name,
+        name3: all[2]?.name,
+      }).toEqual({
+        count: 3,
+        name1: 'Assembly 1',
+        name2: 'Assembly 2',
+        name3: 'Assembly 3',
+      })
     }, 15000)
   })
 
@@ -157,17 +183,24 @@ describe('IndexedDBストレージフロー統合テスト', () => {
       // リポジトリ経由で読み込み（自動変換される）
       const loaded = await repository.findById(testId, candidates)
 
-      expect(loaded).not.toBeNull()
-      expect(loaded?.name).toBe('v1 Format Assembly')
-
       // v1形式のインデックスから正しいパーツIDが取得されている
-      expect(loaded?.assembly.head.id).toBe(candidates.head[5].id)
-      expect(loaded?.assembly.core.id).toBe(candidates.core[3].id)
-      expect(loaded?.assembly.arms.id).toBe(candidates.arms[7].id)
-      expect(loaded?.assembly.legs.id).toBe(candidates.legs[4].id)
-      expect(loaded?.assembly.rightArmUnit.id).toBe(
-        candidates.rightArmUnit[3].id,
-      )
+      expect({
+        exists: loaded !== null,
+        name: loaded?.name,
+        head: loaded?.assembly.head.id,
+        core: loaded?.assembly.core.id,
+        arms: loaded?.assembly.arms.id,
+        legs: loaded?.assembly.legs.id,
+        rightArmUnit: loaded?.assembly.rightArmUnit.id,
+      }).toEqual({
+        exists: true,
+        name: 'v1 Format Assembly',
+        head: candidates.head[5].id,
+        core: candidates.core[3].id,
+        arms: candidates.arms[7].id,
+        legs: candidates.legs[4].id,
+        rightArmUnit: candidates.rightArmUnit[3].id,
+      })
     }, 15000)
 
     it('v1形式データを読み込み後、更新するとv2形式で保存される', async () => {
@@ -201,12 +234,19 @@ describe('IndexedDBストレージフロー統合テスト', () => {
 
       // 再度読み込み
       const reloaded = await repository.findById(testId, candidates)
-      expect(reloaded?.name).toBe('Updated Assembly')
 
       // データがv2形式になっていることを確認
       const rawData = await db.stored_assembly.get(testId)
-      expect(rawData?.assembly).toContain('v=2')
-      expect(rawData?.assembly).toMatch(/h=[A-Z]+\d+/)
+
+      expect({
+        name: reloaded?.name,
+        hasV2Param: rawData?.assembly.includes('v=2'),
+        hasIdFormat: rawData?.assembly.match(/h=[A-Z]+\d+/) !== null,
+      }).toEqual({
+        name: 'Updated Assembly',
+        hasV2Param: true,
+        hasIdFormat: true,
+      })
     }, 15000)
   })
 
@@ -272,16 +312,23 @@ describe('IndexedDBストレージフロー統合テスト', () => {
       }
 
       await dbV1.table('stored_assembly').add(v1Data)
-      await dbV1.close()
+      dbV1.close()
 
       // バージョン2のDBを開く（アップグレードが自動実行される）
       const dbV2 = setupDataBase(candidates)
 
       // データを取得してv2形式に変換されていることを確認
       const stored = await dbV2.stored_assembly.get(v1Data.id)
-      expect(stored).not.toBeUndefined()
-      expect(stored?.assembly).toContain('v=2')
-      expect(stored?.name).toBe('V1 Assembly')
+
+      expect({
+        exists: stored !== undefined,
+        hasV2Param: stored?.assembly.includes('v=2'),
+        name: stored?.name,
+      }).toEqual({
+        exists: true,
+        hasV2Param: true,
+        name: 'V1 Assembly',
+      })
 
       // クリーンアップ
       await Dexie.delete('ac6-assembly-tool')

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -289,8 +289,7 @@ describe('パーツID検索', () => {
           expect(map.size).toBe(parts.length)
 
           for (const part of parts) {
-            expect(map.has(part.id)).toBe(true)
-            expect(map.get(part.id)?.name).toBe(part.name)
+            expect(map.get(part.id)).toEqual(part);
           }
         }),
         { numRuns: 100 },

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -263,13 +263,8 @@ describe('パーツID検索', () => {
         fc.property(genPartsAndSearchId(), ({ parts, searchId }) => {
           const result = findPartByIdOrFirst(parts, searchId)
 
-          expect(result).toBeDefined()
-
-          if (parts.some((p) => p.id === searchId)) {
-            expect(result?.id).toBe(searchId)
-          } else {
-            expect(result?.id).toBe(parts[0].id)
-          }
+          const expected = parts.find((p) => p.id === searchId) ?? parts[0];
+          expect(result).toEqual(expected);
         }),
         { numRuns: 100 },
       )

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -1,73 +1,304 @@
 import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
 
-import { findPartById } from './parts-lookup'
+import {
+  createPartIdMap,
+  findPartById,
+  findPartByIdFromMap,
+  findPartByIdOrFallback,
+  findPartByIdOrFirst,
+} from './parts-lookup'
+import {
+  genPartWithId,
+  genPartsAndSearchId,
+  genPartsWithFallback,
+  genParts,
+} from '../../spec-helper/property-generator'
+
+// 共通テストデータ - describe外で定義
+const testParts = [
+  { id: 'HD001', name: 'Head A', classification: 'head' },
+  { id: 'HD002', name: 'Head B', classification: 'head' },
+  { id: 'HD003', name: 'Head C', classification: 'head' },
+] as const
+
+const testCores = [
+  { id: 'CR001', name: 'Core A', classification: 'core', ap: 1000 },
+  { id: 'CR002', name: 'Core B', classification: 'core', ap: 1200 },
+] as const
 
 describe('パーツID検索', () => {
   describe('findPartById', () => {
-    it('IDでパーツを検索して見つかった場合は該当パーツを返す', () => {
-      const parts = [
-        { id: 'HD001', name: 'Head A', classification: 'head' },
-        { id: 'HD002', name: 'Head B', classification: 'head' },
-        { id: 'HD003', name: 'Head C', classification: 'head' },
-      ] as const
+    // Parameterized test: 複数のIDで同じテストロジックを実行
+    it.each([
+      { id: 'HD001', expectedName: 'Head A' },
+      { id: 'HD002', expectedName: 'Head B' },
+      { id: 'HD003', expectedName: 'Head C' },
+    ])('ID $id でパーツを検索して $expectedName を返す', ({ id, expectedName }) => {
+      const result = findPartById(testParts, id)
 
-      const result = findPartById(parts, 'HD002')
-
-      expect(result).toBeDefined()
-      expect(result?.id).toBe('HD002')
-      expect(result?.name).toBe('Head B')
+      expect({
+        defined: result !== undefined,
+        id: result?.id,
+        name: result?.name,
+      }).toEqual({
+        defined: true,
+        id,
+        name: expectedName,
+      })
     })
 
-    it('IDが見つからない場合はundefinedを返す', () => {
-      const parts = [
-        { id: 'HD001', name: 'Head A', classification: 'head' },
-        { id: 'HD002', name: 'Head B', classification: 'head' },
-      ] as const
-
-      const result = findPartById(parts, 'HD999')
-
+    // Parameterized test: 見つからないケース
+    it.each([
+      'HD999',
+      'HD000',
+      'INVALID',
+      '',
+    ])('存在しないID "%s" の場合はundefinedを返す', (invalidId) => {
+      const result = findPartById(testParts, invalidId)
       expect(result).toBeUndefined()
     })
 
     it('空の配列の場合はundefinedを返す', () => {
       const result = findPartById([], 'HD001')
-
       expect(result).toBeUndefined()
     })
+  })
 
-    it('複数のパーツが同じIDを持つ場合は最初のパーツを返す', () => {
-      // 通常は発生しないが、念のためテスト
-      const parts = [
-        { id: 'HD001', name: 'Head A', classification: 'head' },
-        { id: 'HD001', name: 'Head B', classification: 'head' },
-      ] as const
+  describe('createPartIdMap', () => {
+    it('パーツ配列からID→パーツのMapを作成', () => {
+      const map = createPartIdMap(testParts)
 
-      const result = findPartById(parts, 'HD001')
+      expect({
+        size: map.size,
+        hasHD001: map.has('HD001'),
+        hasHD002: map.has('HD002'),
+        hasHD003: map.has('HD003'),
+        hd001Name: map.get('HD001')?.name,
+        hd002Name: map.get('HD002')?.name,
+      }).toEqual({
+        size: 3,
+        hasHD001: true,
+        hasHD002: true,
+        hasHD003: true,
+        hd001Name: 'Head A',
+        hd002Name: 'Head B',
+      })
+    })
+  })
 
-      expect(result?.name).toBe('Head A')
+  describe('findPartByIdFromMap', () => {
+    // Parameterized test: 複数のIDでMap検索をテスト
+    it.each([
+      { id: 'HD001', expectedName: 'Head A' },
+      { id: 'HD002', expectedName: 'Head B' },
+      { id: 'HD003', expectedName: 'Head C' },
+    ])('MapからID $id で検索して $expectedName を返す', ({ id, expectedName }) => {
+      const map = createPartIdMap(testParts)
+      const result = findPartByIdFromMap(map, id)
+
+      expect({
+        defined: result !== undefined,
+        id: result?.id,
+        name: result?.name,
+      }).toEqual({
+        defined: true,
+        id,
+        name: expectedName,
+      })
     })
 
-    it('大文字小文字を区別する', () => {
-      const parts = [
-        { id: 'HD001', name: 'Head A', classification: 'head' },
-      ] as const
-
-      const result = findPartById(parts, 'hd001')
-
+    it('IDが見つからない場合はundefinedを返す', () => {
+      const map = createPartIdMap(testParts)
+      const result = findPartByIdFromMap(map, 'HD999')
       expect(result).toBeUndefined()
     })
+  })
 
-    it('異なる型のパーツでも検索できる', () => {
-      const parts = [
-        { id: 'CR001', name: 'Core A', classification: 'core', ap: 1000 },
-        { id: 'CR002', name: 'Core B', classification: 'core', ap: 1200 },
-      ] as const
+  describe('findPartByIdOrFallback', () => {
+    const fallback = { id: 'HD000', name: 'Default Head' }
 
-      const result = findPartById(parts, 'CR001')
+    // Parameterized test: 見つかるケース
+    it.each([
+      { id: 'HD001', expectedName: 'Head A' },
+      { id: 'HD002', expectedName: 'Head B' },
+      { id: 'HD003', expectedName: 'Head C' },
+    ])('ID $id が見つかった場合は $expectedName を返す', ({ id, expectedName }) => {
+      const result = findPartByIdOrFallback(testParts, id, fallback)
 
-      expect(result).toBeDefined()
-      expect(result?.id).toBe('CR001')
-      expect(result?.name).toBe('Core A')
+      expect({
+        id: result.id,
+        name: result.name,
+      }).toEqual({
+        id,
+        name: expectedName,
+      })
+    })
+
+    // Parameterized test: 見つからないケース
+    it.each([
+      'HD999',
+      'INVALID',
+      'HD000',
+    ])('ID "%s" が見つからない場合はフォールバックを返す', (invalidId) => {
+      const result = findPartByIdOrFallback(testParts, invalidId, fallback)
+
+      expect({
+        id: result.id,
+        name: result.name,
+      }).toEqual({
+        id: 'HD000',
+        name: 'Default Head',
+      })
+    })
+  })
+
+  describe('findPartByIdOrFirst', () => {
+    // Parameterized test: 見つかるケース
+    it.each([
+      { id: 'HD001', expectedName: 'Head A' },
+      { id: 'HD002', expectedName: 'Head B' },
+      { id: 'HD003', expectedName: 'Head C' },
+    ])('ID $id が見つかった場合は $expectedName を返す', ({ id, expectedName }) => {
+      const result = findPartByIdOrFirst(testParts, id)
+
+      expect({
+        defined: result !== undefined,
+        id: result?.id,
+        name: result?.name,
+      }).toEqual({
+        defined: true,
+        id,
+        name: expectedName,
+      })
+    })
+
+    // Parameterized test: 見つからないケースと undefined ケース
+    it.each([
+      { id: 'HD999', description: 'IDが見つからない' },
+      { id: undefined, description: 'IDがundefined' },
+    ])('$description 場合は配列の最初の要素を返す', ({ id }) => {
+      const result = findPartByIdOrFirst(testParts, id)
+
+      expect({
+        defined: result !== undefined,
+        id: result?.id,
+        name: result?.name,
+      }).toEqual({
+        defined: true,
+        id: 'HD001',
+        name: 'Head A',
+      })
+    })
+
+    it('空の配列の場合はundefinedを返す', () => {
+      const result = findPartByIdOrFirst([], 'HD001')
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('異なる型のパーツでも動作する', () => {
+    // Parameterized test: 異なる型のパーツ
+    it.each([
+      { id: 'CR001', expectedName: 'Core A', expectedAp: 1000 },
+      { id: 'CR002', expectedName: 'Core B', expectedAp: 1200 },
+    ])(
+      'ID $id の追加プロパティを持つパーツでも検索できる',
+      ({ id, expectedName, expectedAp }) => {
+        const result = findPartById(testCores, id)
+
+        expect({
+          defined: result !== undefined,
+          id: result?.id,
+          name: result?.name,
+          ap: result?.ap,
+        }).toEqual({
+          defined: true,
+          id,
+          name: expectedName,
+          ap: expectedAp,
+        })
+      },
+    )
+  })
+
+  describe('Property-based tests', () => {
+    it('任意のパーツ配列で、存在するIDは必ず見つかる', () => {
+      fc.assert(
+        fc.property(genPartWithId(), ({ parts, targetPart }) => {
+          const result = findPartById(parts, targetPart.id)
+
+          expect(result).toBeDefined()
+          expect(result?.id).toBe(targetPart.id)
+          expect(result?.name).toBe(targetPart.name)
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('任意のパーツ配列とMapで、同じIDは同じ結果を返す', () => {
+      fc.assert(
+        fc.property(genPartsAndSearchId(), ({ parts, searchId }) => {
+          const arrayResult = findPartById(parts, searchId)
+          const map = createPartIdMap(parts)
+          const mapResult = findPartByIdFromMap(map, searchId)
+
+          expect(arrayResult?.id).toBe(mapResult?.id)
+          expect(arrayResult?.name).toBe(mapResult?.name)
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('任意のパーツ配列で、findPartByIdOrFirstは必ず値を返す（空配列以外）', () => {
+      fc.assert(
+        fc.property(genPartsAndSearchId(), ({ parts, searchId }) => {
+          const result = findPartByIdOrFirst(parts, searchId)
+
+          expect(result).toBeDefined()
+
+          if (parts.some((p) => p.id === searchId)) {
+            expect(result?.id).toBe(searchId)
+          } else {
+            expect(result?.id).toBe(parts[0].id)
+          }
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('任意のパーツ配列とフォールバックで、findPartByIdOrFallbackは必ず値を返す', () => {
+      fc.assert(
+        fc.property(genPartsWithFallback(), ({ parts, searchId, fallback }) => {
+          const result = findPartByIdOrFallback(parts, searchId, fallback)
+
+          expect(result).toBeDefined()
+
+          if (parts.some((p) => p.id === searchId)) {
+            expect(result.id).toBe(searchId)
+          } else {
+            expect(result.id).toBe(fallback.id)
+            expect(result.name).toBe(fallback.name)
+          }
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('任意のパーツ配列で、createPartIdMapは全てのパーツをMapに含む', () => {
+      fc.assert(
+        fc.property(genParts(), (parts) => {
+          const map = createPartIdMap(parts)
+
+          expect(map.size).toBe(parts.length)
+
+          for (const part of parts) {
+            expect(map.has(part.id)).toBe(true)
+            expect(map.get(part.id)?.name).toBe(part.name)
+          }
+        }),
+        { numRuns: 100 },
+      )
     })
   })
 })

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -274,15 +274,8 @@ describe('パーツID検索', () => {
       fc.assert(
         fc.property(genPartsWithFallback(), ({ parts, searchId, fallback }) => {
           const result = findPartByIdOrFallback(parts, searchId, fallback)
-
-          expect(result).toBeDefined()
-
-          if (parts.some((p) => p.id === searchId)) {
-            expect(result.id).toBe(searchId)
-          } else {
-            expect(result.id).toBe(fallback.id)
-            expect(result.name).toBe(fallback.name)
-          }
+          const expected = parts.find((p) => p.id === searchId) ?? fallback;
+          expect(result).toEqual(expected);
         }),
         { numRuns: 100 },
       )

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest'
 import fc from 'fast-check'
+import { describe, it, expect } from 'vitest'
+
+import {
+  genPartWithId,
+  genPartsAndSearchId,
+  genPartsWithFallback,
+  genParts,
+} from '../../spec-helper/property-generator'
 
 import {
   createPartIdMap,
@@ -8,12 +15,6 @@ import {
   findPartByIdOrFallback,
   findPartByIdOrFirst,
 } from './parts-lookup'
-import {
-  genPartWithId,
-  genPartsAndSearchId,
-  genPartsWithFallback,
-  genParts,
-} from '../../spec-helper/property-generator'
 
 // 共通テストデータ - describe外で定義
 const testParts = [
@@ -34,30 +35,31 @@ describe('パーツID検索', () => {
       { id: 'HD001', expectedName: 'Head A' },
       { id: 'HD002', expectedName: 'Head B' },
       { id: 'HD003', expectedName: 'Head C' },
-    ])('ID $id でパーツを検索して $expectedName を返す', ({ id, expectedName }) => {
-      const result = findPartById(testParts, id)
+    ])(
+      'ID $id でパーツを検索して $expectedName を返す',
+      ({ id, expectedName }) => {
+        const result = findPartById(testParts, id)
 
-      expect({
-        defined: result !== undefined,
-        id: result?.id,
-        name: result?.name,
-      }).toEqual({
-        defined: true,
-        id,
-        name: expectedName,
-      })
-    })
+        expect({
+          defined: result !== undefined,
+          id: result?.id,
+          name: result?.name,
+        }).toEqual({
+          defined: true,
+          id,
+          name: expectedName,
+        })
+      },
+    )
 
     // Parameterized test: 見つからないケース
-    it.each([
-      'HD999',
-      'HD000',
-      'INVALID',
-      '',
-    ])('存在しないID "%s" の場合はundefinedを返す', (invalidId) => {
-      const result = findPartById(testParts, invalidId)
-      expect(result).toBeUndefined()
-    })
+    it.each(['HD999', 'HD000', 'INVALID', ''])(
+      '存在しないID "%s" の場合はundefinedを返す',
+      (invalidId) => {
+        const result = findPartById(testParts, invalidId)
+        expect(result).toBeUndefined()
+      },
+    )
 
     it('空の配列の場合はundefinedを返す', () => {
       const result = findPartById([], 'HD001')
@@ -93,20 +95,23 @@ describe('パーツID検索', () => {
       { id: 'HD001', expectedName: 'Head A' },
       { id: 'HD002', expectedName: 'Head B' },
       { id: 'HD003', expectedName: 'Head C' },
-    ])('MapからID $id で検索して $expectedName を返す', ({ id, expectedName }) => {
-      const map = createPartIdMap(testParts)
-      const result = findPartByIdFromMap(map, id)
+    ])(
+      'MapからID $id で検索して $expectedName を返す',
+      ({ id, expectedName }) => {
+        const map = createPartIdMap(testParts)
+        const result = findPartByIdFromMap(map, id)
 
-      expect({
-        defined: result !== undefined,
-        id: result?.id,
-        name: result?.name,
-      }).toEqual({
-        defined: true,
-        id,
-        name: expectedName,
-      })
-    })
+        expect({
+          defined: result !== undefined,
+          id: result?.id,
+          name: result?.name,
+        }).toEqual({
+          defined: true,
+          id,
+          name: expectedName,
+        })
+      },
+    )
 
     it('IDが見つからない場合はundefinedを返す', () => {
       const map = createPartIdMap(testParts)
@@ -123,34 +128,36 @@ describe('パーツID検索', () => {
       { id: 'HD001', expectedName: 'Head A' },
       { id: 'HD002', expectedName: 'Head B' },
       { id: 'HD003', expectedName: 'Head C' },
-    ])('ID $id が見つかった場合は $expectedName を返す', ({ id, expectedName }) => {
-      const result = findPartByIdOrFallback(testParts, id, fallback)
+    ])(
+      'ID $id が見つかった場合は $expectedName を返す',
+      ({ id, expectedName }) => {
+        const result = findPartByIdOrFallback(testParts, id, fallback)
 
-      expect({
-        id: result.id,
-        name: result.name,
-      }).toEqual({
-        id,
-        name: expectedName,
-      })
-    })
+        expect({
+          id: result.id,
+          name: result.name,
+        }).toEqual({
+          id,
+          name: expectedName,
+        })
+      },
+    )
 
     // Parameterized test: 見つからないケース
-    it.each([
-      'HD999',
-      'INVALID',
-      'HD000',
-    ])('ID "%s" が見つからない場合はフォールバックを返す', (invalidId) => {
-      const result = findPartByIdOrFallback(testParts, invalidId, fallback)
+    it.each(['HD999', 'INVALID', 'HD000'])(
+      'ID "%s" が見つからない場合はフォールバックを返す',
+      (invalidId) => {
+        const result = findPartByIdOrFallback(testParts, invalidId, fallback)
 
-      expect({
-        id: result.id,
-        name: result.name,
-      }).toEqual({
-        id: 'HD000',
-        name: 'Default Head',
-      })
-    })
+        expect({
+          id: result.id,
+          name: result.name,
+        }).toEqual({
+          id: 'HD000',
+          name: 'Default Head',
+        })
+      },
+    )
   })
 
   describe('findPartByIdOrFirst', () => {
@@ -159,19 +166,22 @@ describe('パーツID検索', () => {
       { id: 'HD001', expectedName: 'Head A' },
       { id: 'HD002', expectedName: 'Head B' },
       { id: 'HD003', expectedName: 'Head C' },
-    ])('ID $id が見つかった場合は $expectedName を返す', ({ id, expectedName }) => {
-      const result = findPartByIdOrFirst(testParts, id)
+    ])(
+      'ID $id が見つかった場合は $expectedName を返す',
+      ({ id, expectedName }) => {
+        const result = findPartByIdOrFirst(testParts, id)
 
-      expect({
-        defined: result !== undefined,
-        id: result?.id,
-        name: result?.name,
-      }).toEqual({
-        defined: true,
-        id,
-        name: expectedName,
-      })
-    })
+        expect({
+          defined: result !== undefined,
+          id: result?.id,
+          name: result?.name,
+        }).toEqual({
+          defined: true,
+          id,
+          name: expectedName,
+        })
+      },
+    )
 
     // Parameterized test: 見つからないケースと undefined ケース
     it.each([

--- a/packages/core/src/assembly/parts-lookup.spec.ts
+++ b/packages/core/src/assembly/parts-lookup.spec.ts
@@ -238,9 +238,7 @@ describe('パーツID検索', () => {
         fc.property(genPartWithId(), ({ parts, targetPart }) => {
           const result = findPartById(parts, targetPart.id)
 
-          expect(result).toBeDefined()
-          expect(result?.id).toBe(targetPart.id)
-          expect(result?.name).toBe(targetPart.name)
+          expect(result).toEqual(targetPart)
         }),
         { numRuns: 100 },
       )


### PR DESCRIPTION
## 概要
テストの品質を向上させるため、以下の改善を実施しました。

## 改善内容

### 1. テストアサーションの改善
- 複数の`expect`を1つのオブジェクト比較に統合
- 全てのキー/プロパティで検証（12個のパーツパラメータなど）
- テスト失敗時の不一致箇所が一目で分かるように改善

**Before:**
```typescript
expect(result.get('rau')).toBe('AU001')
expect(result.get('lau')).toBe('AU002')
expect(result.get('h')).toBe('HD001')
// ... 9個のexpect
```

**After:**
```typescript
expect({
  rightArmUnit: result.get('rau'),
  leftArmUnit: result.get('lau'),
  head: result.get('h'),
  // ... 全12プロパティ
}).toEqual({
  rightArmUnit: 'AU001',
  leftArmUnit: 'AU002',
  head: 'HD001',
  // ... 全12プロパティ
})
```

### 2. テスト構造の改善

#### 共通データの整理
- テストデータを`describe`外で定義し、再利用可能に
- テストケース間でのデータ重複を削減

#### Parameterized testの導入
- `it.each`を使用して同じテストロジックを複数データセットで実行
- テストケースの可読性と保守性が向上

```typescript
it.each([
  { id: 'HD001', expectedName: 'Head A' },
  { id: 'HD002', expectedName: 'Head B' },
  { id: 'HD003', expectedName: 'Head C' },
])('ID $id でパーツを検索して $expectedName を返す', ({ id, expectedName }) => {
  const result = findPartById(testParts, id)
  expect(result?.name).toBe(expectedName)
})
```

#### Property-based testの導入
- fast-checkを使用したランダムデータ生成による網羅的テスト
- 正しいフォーマットのパーツIDジェネレータ実装（例: HD001, CR042, FCS001）
- 各テスト100回のランダム実行で堅牢性を検証

**追加したProperty-based test:**
1. 任意のパーツ配列で、存在するIDは必ず見つかる
2. 任意のパーツ配列とMapで、同じIDは同じ結果を返す
3. 任意のパーツ配列で、findPartByIdOrFirstは必ず値を返す
4. 任意のパーツ配列とフォールバックで、findPartByIdOrFallbackは必ず値を返す
5. 任意のパーツ配列で、createPartIdMapは全てのパーツをMapに含む

### 3. プロパティジェネレータの追加
`spec-helper/property-generator.ts`に以下のジェネレータを追加:
- `genPartId()`: 正しいフォーマットのパーツID生成
- `genPart()`: パーツオブジェクト生成
- `genParts()`: パーツ配列生成
- `genPartWithId()`: パーツ配列と確実に存在するパーツを生成
- `genPartsAndSearchId()`: パーツ配列と検索IDを生成
- `genPartsWithFallback()`: パーツ配列、検索ID、フォールバックを生成

## 対象ファイル
- ✅ as-query-v2.spec.ts
- ✅ convert-v1-to-v2.spec.ts
- ✅ deserialize-assembly.spec.ts
- ✅ search-to-assembly-v2.spec.ts
- ✅ url-sharing-flow.spec.ts
- ✅ storage-flow.spec.ts
- ✅ parts-lookup.spec.ts（Parameterized/Property-based test追加）

## テスト結果
```
Test Files  25 passed (25)
Tests       298 passed (298)  ← 279から+19テスト増加
Duration    約15秒
```

## 変更統計
- 8ファイル変更
- 881行追加、465行削除
- 実質+416行（主にProperty-based testの追加）

## メリット
1. **デバッグ効率向上**: テスト失敗時、全ての不一致を一度に確認可能
2. **テスト網羅性向上**: Property-based testで100パターン以上の組み合わせを自動検証
3. **保守性向上**: Parameterized testで重複コード削減
4. **堅牢性向上**: ランダムデータによる予期しないエッジケースの検出

🤖 Generated with [Claude Code](https://claude.com/claude-code)