### PR TITLE
フィルタ適用状態全体をクエリで管理する方針に変更

### DIFF
--- a/.changeset/big-teams-smash.md
+++ b/.changeset/big-teams-smash.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": minor
+---
+
+フィルタの設定状態をURLクエリとして保持
+  

--- a/packages/web/src/lib/view/parts-list/PartsListView.spec.ts
+++ b/packages/web/src/lib/view/parts-list/PartsListView.spec.ts
@@ -13,14 +13,14 @@ import { latest as regulation } from '$lib/regulation'
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import * as navigation from '$app/navigation'
-
 import PartsListView from './PartsListView.svelte'
 import PartsListViewTestWrapper from './PartsListView.test-wrapper.svelte'
 import {
   compressToUrlSafeString,
   decompressFromUrlSafeString,
 } from './state/filter/compression'
+
+import * as navigation from '$app/navigation'
 
 const replaceStateSpy = vi.spyOn(navigation, 'replaceState')
 
@@ -193,9 +193,7 @@ describe('PartsListView コンポーネント', () => {
       const addButton = screen.getByRole('button', { name: '追加' })
       await fireEvent.click(addButton)
 
-      expect(
-        localStorage.getItem('ac6-parts-list-filters-per-slot'),
-      ).toBeNull()
+      expect(localStorage.getItem('ac6-parts-list-filters-per-slot')).toBeNull()
     })
 
     it.skip('表示モード変更時にLocalStorageが更新されること', () => {
@@ -222,10 +220,7 @@ describe('PartsListView コンポーネント', () => {
     it('スロット切替時にフィルタ条件が保持されること（共通属性の場合）', async () => {
       // URLパラメータでフィルタ条件を設定
       const payload = {
-        rightArmUnit: [
-          'numeric:weight:lte:5000',
-          'numeric:price:lte:100000',
-        ],
+        rightArmUnit: ['numeric:weight:lte:5000', 'numeric:price:lte:100000'],
       }
       const compressed = await compressToUrlSafeString(JSON.stringify(payload))
       const searchParams = new URLSearchParams(
@@ -388,6 +383,5 @@ describe('PartsListView コンポーネント', () => {
         expect(screen.getByText(/フィルタ\s*\(1件\)/)).toBeInTheDocument(),
       )
     })
-
   })
 })

--- a/packages/web/src/lib/view/parts-list/PartsListView.svelte
+++ b/packages/web/src/lib/view/parts-list/PartsListView.svelte
@@ -184,7 +184,6 @@
     // スロットを更新
     currentSlot = newSlot
     filters = [...nextFilters]
-    updateFiltersForSlot(newSlot, filters)
 
     // 新しいスロットのお気に入りを読み込み
     if (browser && favoriteStore) {

--- a/packages/web/src/lib/view/parts-list/state/filter/compression.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/compression.spec.ts
@@ -36,12 +36,14 @@ describe('compression utilities', () => {
     expect(decompressed).toBeNull()
   })
 
-  it('throws when CompressionStream API is unavailable', async () => {
+  it('falls back to uncompressed payload when CompressionStream API is unavailable', async () => {
     Reflect.deleteProperty(globalThis, 'CompressionStream')
     Reflect.deleteProperty(globalThis, 'DecompressionStream')
 
-    await expect(compressToUrlSafeString(SAMPLE_TEXT)).rejects.toThrowError(
-      'CompressionStream API is not available in this runtime',
-    )
+    const compressed = await compressToUrlSafeString(SAMPLE_TEXT)
+    expect(compressed).toMatch(/^[A-Za-z0-9_-]+$/u)
+
+    const decompressed = await decompressFromUrlSafeString(compressed)
+    expect(decompressed).toBe(SAMPLE_TEXT)
   })
 })

--- a/packages/web/src/lib/view/parts-list/state/filter/compression.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/compression.ts
@@ -5,7 +5,9 @@ const textDecoder = new TextDecoder()
 
 export async function compressToUrlSafeString(input: string): Promise<string> {
   if (!hasCompressionSupport()) {
-    logger.warn('CompressionStream API is not available, using uncompressed payload')
+    logger.warn(
+      'CompressionStream API is not available, using uncompressed payload',
+    )
     return encodeWithoutCompression(input)
   }
 
@@ -16,9 +18,12 @@ export async function compressToUrlSafeString(input: string): Promise<string> {
     const compressedBuffer = await new Response(compressedStream).arrayBuffer()
     return toBase64Url(new Uint8Array(compressedBuffer))
   } catch (error) {
-    logger.warn('Failed to compress payload, falling back to uncompressed encoding', {
-      error: error instanceof Error ? error.message : String(error),
-    })
+    logger.warn(
+      'Failed to compress payload, falling back to uncompressed encoding',
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    )
     return encodeWithoutCompression(input)
   }
 }
@@ -35,16 +40,25 @@ export async function decompressFromUrlSafeString(
   if (hasCompressionSupport()) {
     try {
       const readable = new Blob([binaryBuffer]).stream()
-      const decompressedStream = readable.pipeThrough(new DecompressionStream('gzip'))
-      const decompressedBuffer = await new Response(decompressedStream).arrayBuffer()
+      const decompressedStream = readable.pipeThrough(
+        new DecompressionStream('gzip'),
+      )
+      const decompressedBuffer = await new Response(
+        decompressedStream,
+      ).arrayBuffer()
       return textDecoder.decode(decompressedBuffer)
     } catch (error) {
-      logger.warn('Failed to decompress payload as gzip, attempting plain decode', {
-        error: error instanceof Error ? error.message : String(error),
-      })
+      logger.warn(
+        'Failed to decompress payload as gzip, attempting plain decode',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
     }
   } else {
-    logger.warn('DecompressionStream API is not available, attempting plain decode')
+    logger.warn(
+      'DecompressionStream API is not available, attempting plain decode',
+    )
   }
 
   return tryDecodePlain(binary)
@@ -52,7 +66,8 @@ export async function decompressFromUrlSafeString(
 
 function hasCompressionSupport(): boolean {
   return (
-    typeof CompressionStream !== 'undefined' && typeof DecompressionStream !== 'undefined'
+    typeof CompressionStream !== 'undefined' &&
+    typeof DecompressionStream !== 'undefined'
   )
 }
 

--- a/packages/web/src/lib/view/parts-list/state/filter/compression.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/compression.ts
@@ -1,57 +1,74 @@
+import { logger } from '@ac6_assemble_tool/shared/logger'
+
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
-/**
- * フィルタシリアライゼーションで利用するURL安全なBase64エンコード済み圧縮文字列を生成
- */
 export async function compressToUrlSafeString(input: string): Promise<string> {
-  assertCompressionSupport()
+  if (!hasCompressionSupport()) {
+    logger.warn('CompressionStream API is not available, using uncompressed payload')
+    return encodeWithoutCompression(input)
+  }
 
-  const stream = new CompressionStream('gzip')
-  const writer = stream.writable.getWriter()
-  await writer.write(textEncoder.encode(input))
-  await writer.close()
-
-  const compressed = await readableStreamToUint8Array(stream.readable)
-  return toBase64Url(compressed)
+  try {
+    const compressedStream = new Blob([input])
+      .stream()
+      .pipeThrough(new CompressionStream('gzip'))
+    const compressedBuffer = await new Response(compressedStream).arrayBuffer()
+    return toBase64Url(new Uint8Array(compressedBuffer))
+  } catch (error) {
+    logger.warn('Failed to compress payload, falling back to uncompressed encoding', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return encodeWithoutCompression(input)
+  }
 }
 
-/**
- * URL安全なBase64文字列を伸長して元の文字列に復元
- */
 export async function decompressFromUrlSafeString(
   compressed: string,
 ): Promise<string | null> {
-  assertCompressionSupport()
-
-  const binary = fromBase64Url(compressed)
-  if (!binary) {
+  const binaryBuffer = fromBase64Url(compressed)
+  if (!binaryBuffer) {
     return null
   }
+  const binary = new Uint8Array(binaryBuffer)
 
-  const stream = new DecompressionStream('gzip')
-  const writer = stream.writable.getWriter()
-  await writer.write(binary)
-  await writer.close()
-
-  const decompressed = await readableStreamToUint8Array(stream.readable)
-  return textDecoder.decode(decompressed)
-}
-
-function assertCompressionSupport(): void {
-  if (
-    typeof CompressionStream === 'undefined' ||
-    typeof DecompressionStream === 'undefined'
-  ) {
-    throw new Error('CompressionStream API is not available in this runtime')
+  if (hasCompressionSupport()) {
+    try {
+      const readable = new Blob([binaryBuffer]).stream()
+      const decompressedStream = readable.pipeThrough(new DecompressionStream('gzip'))
+      const decompressedBuffer = await new Response(decompressedStream).arrayBuffer()
+      return textDecoder.decode(decompressedBuffer)
+    } catch (error) {
+      logger.warn('Failed to decompress payload as gzip, attempting plain decode', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  } else {
+    logger.warn('DecompressionStream API is not available, attempting plain decode')
   }
+
+  return tryDecodePlain(binary)
 }
 
-async function readableStreamToUint8Array(
-  stream: ReadableStream<Uint8Array>,
-): Promise<Uint8Array> {
-  const buffer = await new Response(stream).arrayBuffer()
-  return new Uint8Array(buffer)
+function hasCompressionSupport(): boolean {
+  return (
+    typeof CompressionStream !== 'undefined' && typeof DecompressionStream !== 'undefined'
+  )
+}
+
+function encodeWithoutCompression(input: string): string {
+  return toBase64Url(textEncoder.encode(input))
+}
+
+function tryDecodePlain(bytes: Uint8Array): string | null {
+  try {
+    return textDecoder.decode(bytes)
+  } catch (error) {
+    logger.error('Failed to decode payload', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
 }
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -64,7 +81,7 @@ function toBase64Url(bytes: Uint8Array): string {
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '')
 }
 
-function fromBase64Url(value: string): Uint8Array<ArrayBuffer> | null {
+function fromBase64Url(value: string): ArrayBuffer | null {
   if (!value) {
     return null
   }
@@ -75,12 +92,12 @@ function fromBase64Url(value: string): Uint8Array<ArrayBuffer> | null {
 
   try {
     const binary = atob(padded)
-    const buffer = new ArrayBuffer(binary.length)
-    const bytes = new Uint8Array(buffer)
+    const arrayBuffer = new ArrayBuffer(binary.length)
+    const bytes = new Uint8Array(arrayBuffer)
     for (let i = 0; i < binary.length; i += 1) {
       bytes[i] = binary.charCodeAt(i)
     }
-    return bytes
+    return arrayBuffer
   } catch {
     return null
   }

--- a/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
@@ -56,5 +56,4 @@ describe('filter serialization utilities', () => {
       expect(normalizeSlotKey('invalid_slot')).toBeNull()
     })
   })
-
 })

--- a/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
@@ -116,9 +116,7 @@ describe('filter serialization utilities', () => {
           buildNameFilter(stringOp[0], 'zimmer'),
         ],
         head: [],
-        leftArmUnit: [
-          buildManufactureFilter(selectAnyOperand(), ['balam']),
-        ],
+        leftArmUnit: [buildManufactureFilter(selectAnyOperand(), ['balam'])],
       }
 
       const serialized = serializeFiltersPerSlot(filtersPerSlot)

--- a/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/serialization.spec.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  buildManufactureFilter,
-  buildNameFilter,
-  buildPropertyFilter,
-} from './filters-application'
-import {
-  numericOperands,
-  selectAnyOperand,
-  stringOperands,
-} from './filters-core'
-import {
-  deserializeFiltersForSlot,
-  deserializeFiltersPerSlot,
-  normalizeSlotKey,
-  parseFilter,
-  serializeFiltersForSlot,
-  serializeFiltersPerSlot,
-  toSlotParamKey,
-  type FiltersPerSlot,
-} from './serialization'
-
-const numericOp = numericOperands()
-const stringOp = stringOperands()
+import { normalizeSlotKey, parseFilter } from './serialization'
 
 describe('filter serialization utilities', () => {
   describe('parseFilter', () => {
@@ -65,93 +43,6 @@ describe('filter serialization utilities', () => {
     })
   })
 
-  describe('serializeFiltersForSlot', () => {
-    it('複数フィルタを区切り文字で連結すること', () => {
-      const filters = [
-        buildPropertyFilter('weight', numericOp[0], 300),
-        buildNameFilter(stringOp[0], 'zimmer'),
-      ]
-      expect(serializeFiltersForSlot(filters)).toBe(
-        'numeric:weight:lte:300|string:name:contain:zimmer',
-      )
-    })
-
-    it('空配列は空文字列を返すこと', () => {
-      expect(serializeFiltersForSlot([])).toBe('')
-    })
-  })
-
-  describe('deserializeFiltersForSlot', () => {
-    it('区切り文字で連結されたフィルタを復元すること', async () => {
-      const serialized =
-        'numeric:weight:lte:300|string:name:contain:zimmer|array:manufacture:in_any:balam'
-      const result = await deserializeFiltersForSlot(serialized)
-      expect(result.type).toBe('Success')
-      if (result.type === 'Success') {
-        expect(result.value).toHaveLength(3)
-        expect(result.value[0].serialize()).toBe('numeric:weight:lte:300')
-        expect(result.value[1].serialize()).toBe('string:name:contain:zimmer')
-        expect(result.value[2].serialize()).toBe(
-          'array:manufacture:in_any:balam',
-        )
-      }
-    })
-
-    it('無効なフィルタはスキップされること', async () => {
-      const serialized = 'invalid|numeric:weight:lte:300'
-      const result = await deserializeFiltersForSlot(serialized)
-      expect(result.type).toBe('Success')
-      if (result.type === 'Success') {
-        expect(result.value).toHaveLength(1)
-        expect(result.value[0].serialize()).toBe('numeric:weight:lte:300')
-      }
-    })
-  })
-
-  describe('serializeFiltersPerSlot', () => {
-    it('フィルタが存在するスロットのみを含めること', () => {
-      const filtersPerSlot: FiltersPerSlot = {
-        rightArmUnit: [
-          buildPropertyFilter('weight', numericOp[0], 300),
-          buildNameFilter(stringOp[0], 'zimmer'),
-        ],
-        head: [],
-        leftArmUnit: [buildManufactureFilter(selectAnyOperand(), ['balam'])],
-      }
-
-      const serialized = serializeFiltersPerSlot(filtersPerSlot)
-      expect(serialized.size).toBe(2)
-      expect(serialized.get('right_arm_unit_filters')).toBe(
-        'numeric:weight:lte:300|string:name:contain:zimmer',
-      )
-      expect(serialized.get('left_arm_unit_filters')).toBe(
-        'array:manufacture:in_any:balam',
-      )
-      expect(serialized.has('head_filters')).toBe(false)
-    })
-  })
-
-  describe('deserializeFiltersPerSlot', () => {
-    it('URLSearchParamsから各スロットのフィルタを復元すること', async () => {
-      const params = new URLSearchParams()
-      params.set(
-        'right_arm_unit_filters',
-        'numeric:weight:lte:300|string:name:contain:zimmer',
-      )
-      params.set('head_filters', 'string:name:contain:rabbit')
-
-      const restored = deserializeFiltersPerSlot(params)
-      expect(restored.rightArmUnit?.map((f) => f.serialize())).toEqual([
-        'numeric:weight:lte:300',
-        'string:name:contain:zimmer',
-      ])
-      expect(restored.head?.map((f) => f.serialize())).toEqual([
-        'string:name:contain:rabbit',
-      ])
-      expect(restored.leftArmUnit).toBeUndefined()
-    })
-  })
-
   describe('normalizeSlotKey', () => {
     it.each([
       ['rightArmUnit', 'rightArmUnit'],
@@ -166,10 +57,4 @@ describe('filter serialization utilities', () => {
     })
   })
 
-  describe('toSlotParamKey', () => {
-    it('スロット名をスネークケースのクエリキーに変換すること', () => {
-      expect(toSlotParamKey('rightArmUnit')).toBe('right_arm_unit_filters')
-      expect(toSlotParamKey('leftBackUnit')).toBe('left_back_unit_filters')
-    })
-  })
 })

--- a/packages/web/src/lib/view/parts-list/state/filter/serialization.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/serialization.ts
@@ -175,7 +175,9 @@ export function toSlotParamKey(slot: CandidatesKey): string {
   return `${camelToSnake(slot)}_filters`
 }
 
-export function serializeFiltersPerSlot(filtersPerSlot: FiltersPerSlot): ReadonlyMap<string, string> {
+export function serializeFiltersPerSlot(
+  filtersPerSlot: FiltersPerSlot,
+): ReadonlyMap<string, string> {
   const entries: [string, string][] = []
   for (const slot of CANDIDATES_KEYS) {
     const filters = filtersPerSlot[slot]
@@ -268,14 +270,19 @@ export async function deserializeLegacyFiltersPerSlotFromURL(
     const restored: FiltersPerSlot = {}
     for (const [slotKey, serializedFilters] of Object.entries(parsed)) {
       if (!VALID_SLOTS.has(slotKey as CandidatesKey)) {
-        logger.warn('Invalid slot in legacy filters, skipping', { slot: slotKey })
+        logger.warn('Invalid slot in legacy filters, skipping', {
+          slot: slotKey,
+        })
         continue
       }
 
       if (!Array.isArray(serializedFilters)) {
-        logger.warn('Filters for slot from legacy data is not an array, skipping', {
-          slot: slotKey,
-        })
+        logger.warn(
+          'Filters for slot from legacy data is not an array, skipping',
+          {
+            slot: slotKey,
+          },
+        )
         continue
       }
 
@@ -310,7 +317,9 @@ export async function deserializeLegacyFiltersPerSlotFromURL(
   }
 }
 
-function isSerializedFiltersRecord(value: unknown): value is SerializedFiltersPerSlot {
+function isSerializedFiltersRecord(
+  value: unknown,
+): value is SerializedFiltersPerSlot {
   if (typeof value !== 'object' || value === null) {
     return false
   }
@@ -319,6 +328,8 @@ function isSerializedFiltersRecord(value: unknown): value is SerializedFiltersPe
     if (!Array.isArray(entry)) {
       return false
     }
-    return entry.every((filter) => typeof filter === 'string' && filter.length > 0)
+    return entry.every(
+      (filter) => typeof filter === 'string' && filter.length > 0,
+    )
   })
 }

--- a/packages/web/src/lib/view/parts-list/state/filter/serialization.ts
+++ b/packages/web/src/lib/view/parts-list/state/filter/serialization.ts
@@ -7,10 +7,7 @@ import { Result } from '@praha/byethrow'
 
 import { VALID_SLOTS, type DeserializeError } from '../shared'
 
-import {
-  compressToUrlSafeString,
-  decompressFromUrlSafeString,
-} from './compression'
+import { decompressFromUrlSafeString } from './compression'
 import {
   buildPropertyFilter,
   buildNameFilter,
@@ -24,11 +21,6 @@ import {
   selectAnyOperand,
   stringOperands,
 } from './filters-core'
-
-/**
- * LocalStorageに保存するスロットごとのフィルタ状態のキー
- */
-const FILTERS_PER_SLOT_KEY = 'ac6-parts-list-filters-per-slot'
 
 /**
  * フィルタパラメータをパース
@@ -131,170 +123,32 @@ export function parseFilter(filterParam: string): Filter | null {
  * フィルタが設定されているスロットのみを含める（URL長を削減）
  * CompressionStream(Gzip)圧縮を使用してURLサイズを削減
  */
-export async function serializeFiltersPerSlotToURL(
-  filtersPerSlot: FiltersPerSlot,
-): Promise<string> {
-  // 空のフィルタを持つスロットを除外
-  const nonEmptyFilters: FiltersPerSlot = {}
-  for (const [slot, filters] of Object.entries(filtersPerSlot)) {
-    if (filters && filters.length > 0) {
-      nonEmptyFilters[slot as CandidatesKey] = filters
-    }
-  }
-
-  // フィルタが1つもない場合は空文字列を返す
-  if (Object.keys(nonEmptyFilters).length === 0) {
-    return ''
-  }
-
-  // JSON → 圧縮 → URLパラメータ
-  const json = JSON.stringify(nonEmptyFilters)
-  try {
-    return await compressToUrlSafeString(json)
-  } catch (error) {
-    logger.error('Failed to compress filters per slot for URL', {
-      error,
-    })
-    return ''
-  }
+export function serializeFiltersForSlot(filters: readonly Filter[]): string {
+  return filters.map((filter) => filter.serialize()).join('|')
 }
 
-/**
- * URLパラメータからスロットごとのフィルタ状態を復元
- */
-export async function deserializeFiltersPerSlotFromURL(
-  compressedFilters: string,
-): Promise<Result.Result<FiltersPerSlot, DeserializeError>> {
-  if (!compressedFilters) {
-    // フィルタパラメータがない場合は空のオブジェクトを返す
-    return Result.succeed({})
+export function deserializeFiltersForSlot(
+  serialized: string,
+): Result.Result<Filter[], DeserializeError> {
+  if (!serialized) {
+    return Result.succeed([])
   }
 
-  try {
-    const json = await decompressFromUrlSafeString(compressedFilters)
-    if (!json) {
-      return Result.fail({
-        type: 'invalid_format',
-        message: 'Failed to decompress filters',
+  const items = serialized.split('|').filter((entry) => entry.trim().length > 0)
+  const filters: Filter[] = []
+
+  for (const entry of items) {
+    const parsed = parseFilter(entry)
+    if (!parsed) {
+      logger.warn('Invalid filter entry in filters per slot, skipping', {
+        filterParam: entry,
       })
+      continue
     }
-
-    const parsed = JSON.parse(json)
-
-    // 基本的な型チェック
-    if (typeof parsed !== 'object' || parsed === null) {
-      return Result.fail({
-        type: 'invalid_format',
-        message: 'Parsed filters is not an object',
-      })
-    }
-
-    // 各スロットのフィルタを検証（簡易版）
-    const validated: FiltersPerSlot = {}
-    for (const [slot, filters] of Object.entries(parsed)) {
-      // スロット名の検証
-      if (!VALID_SLOTS.has(slot as CandidatesKey)) {
-        logger.warn('Invalid slot in filters per slot, skipping', { slot })
-        continue
-      }
-
-      // filtersが配列かチェック
-      if (!Array.isArray(filters)) {
-        logger.warn('Filters for slot is not an array, skipping', { slot })
-        continue
-      }
-
-      validated[slot as CandidatesKey] = filters as Filter[]
-    }
-
-    return Result.succeed(validated)
-  } catch (error) {
-    logger.error('Failed to deserialize filters per slot from URL', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-
-    return Result.fail({
-      type: 'invalid_format',
-      message: error instanceof Error ? error.message : String(error),
-    })
+    filters.push(parsed)
   }
-}
 
-/**
- * スロットごとのフィルタ状態をLocalStorageに保存
- */
-export function saveFiltersPerSlotToLocalStorage(
-  filtersPerSlot: FiltersPerSlot,
-): void {
-  try {
-    const serializable = Object.entries(filtersPerSlot).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: value.map((f) => f.serialize()),
-      }),
-      {} as Record<string, string[]>,
-    )
-
-    localStorage.setItem(FILTERS_PER_SLOT_KEY, JSON.stringify(serializable))
-  } catch (error) {
-    logger.error('Failed to save filters per slot to localStorage', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-  }
-}
-
-/**
- * LocalStorageからスロットごとのフィルタ状態を復元
- */
-export function loadFiltersPerSlotFromLocalStorage(): FiltersPerSlot | null {
-  try {
-    const saved = localStorage.getItem(FILTERS_PER_SLOT_KEY)
-    if (!saved) return null
-
-    const parsed = JSON.parse(saved) as Record<string, string[]>
-    // 基本的な型チェック
-    if (typeof parsed !== 'object' || parsed === null) {
-      logger.warn('Invalid filters per slot in localStorage')
-      return null
-    }
-
-    return Object.entries(parsed).reduce((acc, [slot, serializedFilters]) => {
-      // スロット名の検証
-      if (!VALID_SLOTS.has(slot as CandidatesKey)) {
-        logger.warn(
-          'Invalid slot in filters per slot from localStorage, skipping',
-          { slot },
-        )
-        return acc
-      }
-
-      // serializedFiltersが配列かチェック
-      if (!Array.isArray(serializedFilters)) {
-        logger.warn(
-          'Filters for slot from localStorage is not an array, skipping',
-          { slot },
-        )
-        return acc
-      }
-      const filters: Filter[] = []
-      for (const serializedFilter of serializedFilters) {
-        const parsedFilter = parseFilter(serializedFilter)
-        if (parsedFilter) {
-          filters.push(parsedFilter)
-        }
-      }
-
-      return {
-        ...acc,
-        [slot as CandidatesKey]: filters,
-      }
-    }, {} as FiltersPerSlot)
-  } catch (error) {
-    logger.error('Failed to load filters per slot from localStorage', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return null
-  }
+  return Result.succeed(filters)
 }
 
 /**
@@ -315,4 +169,156 @@ export function createDefaultFiltersPerSlot(): FiltersPerSlot {
 
 export type FiltersPerSlot = {
   [K in CandidatesKey]?: Filter[]
+}
+
+export function toSlotParamKey(slot: CandidatesKey): string {
+  return `${camelToSnake(slot)}_filters`
+}
+
+export function serializeFiltersPerSlot(filtersPerSlot: FiltersPerSlot): ReadonlyMap<string, string> {
+  const entries: [string, string][] = []
+  for (const slot of CANDIDATES_KEYS) {
+    const filters = filtersPerSlot[slot]
+    if (!filters || filters.length === 0) {
+      continue
+    }
+
+    const serialized = serializeFiltersForSlot(filters)
+    if (serialized.length > 0) {
+      entries.push([toSlotParamKey(slot), serialized])
+    }
+  }
+
+  return new Map(entries)
+}
+
+export function deserializeFiltersPerSlot(
+  params: URLSearchParams,
+): FiltersPerSlot {
+  const restored: FiltersPerSlot = {}
+
+  for (const slot of CANDIDATES_KEYS) {
+    const paramKey = toSlotParamKey(slot)
+    const serialized = params.get(paramKey)
+    if (!serialized) continue
+
+    const result = deserializeFiltersForSlot(serialized)
+    if (Result.isSuccess(result) && result.value.length > 0) {
+      restored[slot] = result.value
+    }
+  }
+
+  return restored
+}
+
+export function normalizeSlotKey(value: string): CandidatesKey | null {
+  if (!value) {
+    return null
+  }
+
+  if (VALID_SLOTS.has(value as CandidatesKey)) {
+    return value as CandidatesKey
+  }
+
+  const camel = snakeToCamel(value)
+  if (VALID_SLOTS.has(camel as CandidatesKey)) {
+    return camel as CandidatesKey
+  }
+
+  return null
+}
+
+function camelToSnake(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase()
+}
+
+function snakeToCamel(value: string): string {
+  return value.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase())
+}
+
+type SerializedFiltersPerSlot = Record<string, string[]>
+
+export async function deserializeLegacyFiltersPerSlotFromURL(
+  compressedFilters: string,
+): Promise<Result.Result<FiltersPerSlot, DeserializeError>> {
+  if (!compressedFilters) {
+    return Result.succeed({})
+  }
+
+  try {
+    const json = await decompressFromUrlSafeString(compressedFilters)
+    if (!json) {
+      return Result.fail({
+        type: 'invalid_format',
+        message: 'Failed to decompress filters',
+      })
+    }
+
+    const parsed = JSON.parse(json) as unknown
+    if (!isSerializedFiltersRecord(parsed)) {
+      return Result.fail({
+        type: 'invalid_format',
+        message: 'Parsed filters is not an object',
+      })
+    }
+
+    const restored: FiltersPerSlot = {}
+    for (const [slotKey, serializedFilters] of Object.entries(parsed)) {
+      if (!VALID_SLOTS.has(slotKey as CandidatesKey)) {
+        logger.warn('Invalid slot in legacy filters, skipping', { slot: slotKey })
+        continue
+      }
+
+      if (!Array.isArray(serializedFilters)) {
+        logger.warn('Filters for slot from legacy data is not an array, skipping', {
+          slot: slotKey,
+        })
+        continue
+      }
+
+      const filters: Filter[] = []
+      for (const serializedFilter of serializedFilters) {
+        const parsedFilter = parseFilter(serializedFilter)
+        if (!parsedFilter) {
+          logger.warn('Invalid legacy filter entry skipped', {
+            slot: slotKey,
+            serializedFilter,
+          })
+          continue
+        }
+        filters.push(parsedFilter)
+      }
+
+      if (filters.length > 0) {
+        restored[slotKey as CandidatesKey] = filters
+      }
+    }
+
+    return Result.succeed(restored)
+  } catch (error) {
+    logger.error('Failed to deserialize legacy filters per slot from URL', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    return Result.fail({
+      type: 'invalid_format',
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+function isSerializedFiltersRecord(value: unknown): value is SerializedFiltersPerSlot {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  return Object.values(value as Record<string, unknown>).every((entry) => {
+    if (!Array.isArray(entry)) {
+      return false
+    }
+    return entry.every((filter) => typeof filter === 'string' && filter.length > 0)
+  })
 }

--- a/packages/web/src/lib/view/parts-list/state/state-serializer.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/state-serializer.spec.ts
@@ -2,6 +2,10 @@ import { Result } from '@praha/byethrow'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  compressToUrlSafeString,
+  decompressFromUrlSafeString,
+} from './filter/compression'
+import {
   buildCategoryFilter,
   buildManufactureFilter,
   buildNameFilter,
@@ -17,10 +21,6 @@ import {
   serializeToURL,
   type SharedState,
 } from './state-serializer'
-import {
-  compressToUrlSafeString,
-  decompressFromUrlSafeString,
-} from './filter/compression'
 
 describe('StateSerializer', () => {
   beforeEach(() => {
@@ -148,10 +148,7 @@ describe('StateSerializer', () => {
 
     it('圧縮filtersパラメータからフィルタを復元できること', async () => {
       const payload = {
-        arms: [
-          'numeric:weight:lt:5000',
-          'string:name:contain:ZIMMER',
-        ],
+        arms: ['numeric:weight:lt:5000', 'string:name:contain:ZIMMER'],
         rightArmUnit: [
           'numeric:price:lte:100000',
           'array:manufacture:in_any:BALAM,FURLONG',
@@ -227,9 +224,9 @@ describe('StateSerializer', () => {
 
       expect(Result.isSuccess(result)).toBe(true)
       if (result.type === 'Success') {
-        expect(result.value.filtersPerSlot.head?.map((f) => f.serialize())).toEqual([
-          'string:name:contain:ZIMMER',
-        ])
+        expect(
+          result.value.filtersPerSlot.head?.map((f) => f.serialize()),
+        ).toEqual(['string:name:contain:ZIMMER'])
         expect(result.value.filtersPerSlot.rightArmUnit).toBeUndefined()
       }
     })
@@ -237,7 +234,9 @@ describe('StateSerializer', () => {
     it('URLパラメータから並び替え設定を復元できること', async () => {
       const payload = {}
       const compressed = await compressToUrlSafeString(JSON.stringify(payload))
-      const params = new URLSearchParams(`slot=legs&filters=${compressed}&sort=weight:asc`)
+      const params = new URLSearchParams(
+        `slot=legs&filters=${compressed}&sort=weight:asc`,
+      )
 
       const result = await deserializeFromURL(params)
 

--- a/packages/web/src/lib/view/parts-list/state/state-serializer.ts
+++ b/packages/web/src/lib/view/parts-list/state/state-serializer.ts
@@ -5,7 +5,10 @@ import {
 import { logger } from '@ac6_assemble_tool/shared/logger'
 import { Result } from '@praha/byethrow'
 
-import { compressToUrlSafeString, decompressFromUrlSafeString } from './filter/compression'
+import {
+  compressToUrlSafeString,
+  decompressFromUrlSafeString,
+} from './filter/compression'
 import { type Filter } from './filter/filters-core'
 import {
   normalizeSlotKey,
@@ -32,7 +35,9 @@ export interface SharedState {
 /**
  * URLパラメータへのシリアライズ（共有用）
  */
-export async function serializeToURL(state: SharedState): Promise<URLSearchParams> {
+export async function serializeToURL(
+  state: SharedState,
+): Promise<URLSearchParams> {
   const params = new URLSearchParams()
 
   // スロット
@@ -66,7 +71,9 @@ async function serializeFiltersParam(
   return compressToUrlSafeString(json)
 }
 
-function buildFiltersPayload(filtersPerSlot: FiltersPerSlot): SerializedFiltersPayload | null {
+function buildFiltersPayload(
+  filtersPerSlot: FiltersPerSlot,
+): SerializedFiltersPayload | null {
   const payload: SerializedFiltersPayload = {}
   let hasFilters = false
 
@@ -117,7 +124,9 @@ async function deserializeFiltersParam(
   const restored: FiltersPerSlot = {}
   for (const [slotKey, serializedFilters] of Object.entries(parsed)) {
     if (!isValidSlotKey(slotKey)) {
-      logger.warn('Invalid slot in filters payload, skipping', { slot: slotKey })
+      logger.warn('Invalid slot in filters payload, skipping', {
+        slot: slotKey,
+      })
       continue
     }
 
@@ -142,7 +151,9 @@ async function deserializeFiltersParam(
   return Result.succeed(restored)
 }
 
-function isSerializedFiltersPayload(value: unknown): value is SerializedFiltersPayload {
+function isSerializedFiltersPayload(
+  value: unknown,
+): value is SerializedFiltersPayload {
   if (typeof value !== 'object' || value === null) {
     return false
   }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
+    watch: {
+      usePolling: true,
+    },
   },
   preview: {
     host: '0.0.0.0',


### PR DESCRIPTION
## このPRの目的

フィルタ適用状態全体をクエリで管理し、共有・復元可能にするため

## 主な変更点

- LocalStorageを使わず、クエリでフィルタ適用状態を保持
- URLクエリのうち、フィルタ適用状態を圧縮して保持・復元

## レビュー観点

- gzip圧縮/伸長処理の例外ハンドリングおよび型整合性が保たれているか
- `pnpm web check-types`の通過を確認済みであること

## 関連Issue / ADR

- Issue: #871
- ADR: なし

## チェックリスト

- [x] 関連するIssueに紐づけた
- [ ] CIが成功している
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した
