### PR TITLE
本来装備できないパーツが装備できてしまう問題を修正

### DIFF
--- a/.changeset/plenty-ideas-find.md
+++ b/.changeset/plenty-ideas-find.md
@@ -1,0 +1,7 @@
+---
+"@ac6_assemble_tool/core": patch
+"@ac6_assemble_tool/web": patch
+---
+
+fix bug when tank legs are selected
+  

--- a/packages/core/src/assembly/command/change-assembly.spec.ts
+++ b/packages/core/src/assembly/command/change-assembly.spec.ts
@@ -1,7 +1,4 @@
-import {
-  type Assembly,
-  createAssembly,
-} from '#core/assembly/assembly'
+import { type Assembly, createAssembly } from '#core/assembly/assembly'
 import { changeAssemblyCommand } from '#core/assembly/command/change-assembly'
 
 import { boosterNotEquipped } from '@ac6_assemble_tool/parts/not-equipped'
@@ -44,45 +41,63 @@ describe('changeAssembly', () => {
   })
 
   it('右手武器を装備すると同一装備を右肩候補から除外する', () => {
-    const armUnit = findSharedArmUnit(candidates.rightArmUnit, candidates.rightBackUnit)
+    const armUnit = findSharedArmUnit(
+      candidates.rightArmUnit,
+      candidates.rightBackUnit,
+    )
 
     const result = change('rightArmUnit', armUnit, baseAssembly)
 
     expect(result.assembly.rightArmUnit).toBe(armUnit)
-    expect(result.remainingCandidates.rightBackUnit.some((p) => p.id === armUnit.id)).toBe(
-      false,
-    )
+    expect(
+      result.remainingCandidates.rightBackUnit.some((p) => p.id === armUnit.id),
+    ).toBe(false)
   })
 
   it('右肩で腕武器を装備すると同一装備を右手候補から除外する', () => {
-    const armUnitOnBack = findSharedArmUnit(candidates.rightBackUnit, candidates.rightArmUnit)
+    const armUnitOnBack = findSharedArmUnit(
+      candidates.rightBackUnit,
+      candidates.rightArmUnit,
+    )
 
     const result = change('rightBackUnit', armUnitOnBack, baseAssembly)
 
     expect(result.assembly.rightBackUnit).toBe(armUnitOnBack)
-    expect(result.remainingCandidates.rightArmUnit.some((p) => p.id === armUnitOnBack.id)).toBe(
-      false,
-    )
+    expect(
+      result.remainingCandidates.rightArmUnit.some(
+        (p) => p.id === armUnitOnBack.id,
+      ),
+    ).toBe(false)
   })
 
   it('左手武器を装備すると同一装備を左肩候補から除外する', () => {
-    const armUnit = findSharedArmUnit(candidates.leftArmUnit, candidates.leftBackUnit)
+    const armUnit = findSharedArmUnit(
+      candidates.leftArmUnit,
+      candidates.leftBackUnit,
+    )
 
     const result = change('leftArmUnit', armUnit, baseAssembly)
 
     expect(result.assembly.leftArmUnit).toBe(armUnit)
-    expect(result.remainingCandidates.leftBackUnit.some((p) => p.id === armUnit.id)).toBe(false)
+    expect(
+      result.remainingCandidates.leftBackUnit.some((p) => p.id === armUnit.id),
+    ).toBe(false)
   })
 
   it('左肩で腕武器を装備すると同一装備を左手候補から除外する', () => {
-    const armUnitOnBack = findSharedArmUnit(candidates.leftBackUnit, candidates.leftArmUnit)
+    const armUnitOnBack = findSharedArmUnit(
+      candidates.leftBackUnit,
+      candidates.leftArmUnit,
+    )
 
     const result = change('leftBackUnit', armUnitOnBack, baseAssembly)
 
     expect(result.assembly.leftBackUnit).toBe(armUnitOnBack)
-    expect(result.remainingCandidates.leftArmUnit.some((p) => p.id === armUnitOnBack.id)).toBe(
-      false,
-    )
+    expect(
+      result.remainingCandidates.leftArmUnit.some(
+        (p) => p.id === armUnitOnBack.id,
+      ),
+    ).toBe(false)
   })
 
   it('制約対象外のスロット変更では候補一覧を変更しない', () => {
@@ -112,7 +127,9 @@ function createAssemblyFromCandidates(base: Candidates): Assembly {
   } as never)
 }
 
-function pickEquippable<T extends { classification: string }>(parts: readonly T[]): T {
+function pickEquippable<T extends { classification: string }>(
+  parts: readonly T[],
+): T {
   const found = parts.find((part) => part.classification !== notEquipped)
   if (!found) {
     throw new Error('有効な候補が存在しません')
@@ -126,7 +143,9 @@ function findSharedArmUnit<T extends { classification: string; id: string }>(
   target: readonly { id: string }[],
 ): T {
   const found = source.find(
-    (part) => part.classification !== notEquipped && target.some((candidate) => candidate.id === part.id),
+    (part) =>
+      part.classification !== notEquipped &&
+      target.some((candidate) => candidate.id === part.id),
   )
   if (!found) {
     throw new Error('共有可能な武器が見つかりません')

--- a/packages/core/src/assembly/command/change-assembly.spec.ts
+++ b/packages/core/src/assembly/command/change-assembly.spec.ts
@@ -1,0 +1,136 @@
+import {
+  type Assembly,
+  createAssembly,
+} from '#core/assembly/assembly'
+import { changeAssemblyCommand } from '#core/assembly/command/change-assembly'
+
+import { boosterNotEquipped } from '@ac6_assemble_tool/parts/not-equipped'
+import { tank } from '@ac6_assemble_tool/parts/types/base/category'
+import { notEquipped } from '@ac6_assemble_tool/parts/types/base/classification'
+import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
+import { candidates } from '@ac6_assemble_tool/parts/versions/v1.07'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('changeAssembly', () => {
+  const change = changeAssemblyCommand(candidates)
+  let baseAssembly: Assembly
+
+  beforeEach(() => {
+    baseAssembly = createAssemblyFromCandidates(candidates)
+  })
+
+  it('タンク脚部を選択した場合はブースターを未装備にする', () => {
+    const tankLeg = candidates.legs.find((leg) => leg.category === tank)
+    if (!tankLeg) {
+      throw new Error('タンク脚部の候補が見つかりません')
+    }
+
+    const result = change('legs', tankLeg, baseAssembly)
+
+    expect(result.assembly.legs).toBe(tankLeg)
+    expect(result.assembly.booster).toBe(boosterNotEquipped)
+  })
+
+  it('タンク脚部を選択した場合はブースター候補を未装備のみにする', () => {
+    const tankLeg = candidates.legs.find((leg) => leg.category === tank)
+    if (!tankLeg) {
+      throw new Error('タンク脚部の候補が見つかりません')
+    }
+
+    const result = change('legs', tankLeg, baseAssembly)
+
+    expect(result.assembly.legs).toBe(tankLeg)
+    expect(result.remainingCandidates.booster).toEqual([boosterNotEquipped])
+  })
+
+  it('右手武器を装備すると同一装備を右肩候補から除外する', () => {
+    const armUnit = findSharedArmUnit(candidates.rightArmUnit, candidates.rightBackUnit)
+
+    const result = change('rightArmUnit', armUnit, baseAssembly)
+
+    expect(result.assembly.rightArmUnit).toBe(armUnit)
+    expect(result.remainingCandidates.rightBackUnit.some((p) => p.id === armUnit.id)).toBe(
+      false,
+    )
+  })
+
+  it('右肩で腕武器を装備すると同一装備を右手候補から除外する', () => {
+    const armUnitOnBack = findSharedArmUnit(candidates.rightBackUnit, candidates.rightArmUnit)
+
+    const result = change('rightBackUnit', armUnitOnBack, baseAssembly)
+
+    expect(result.assembly.rightBackUnit).toBe(armUnitOnBack)
+    expect(result.remainingCandidates.rightArmUnit.some((p) => p.id === armUnitOnBack.id)).toBe(
+      false,
+    )
+  })
+
+  it('左手武器を装備すると同一装備を左肩候補から除外する', () => {
+    const armUnit = findSharedArmUnit(candidates.leftArmUnit, candidates.leftBackUnit)
+
+    const result = change('leftArmUnit', armUnit, baseAssembly)
+
+    expect(result.assembly.leftArmUnit).toBe(armUnit)
+    expect(result.remainingCandidates.leftBackUnit.some((p) => p.id === armUnit.id)).toBe(false)
+  })
+
+  it('左肩で腕武器を装備すると同一装備を左手候補から除外する', () => {
+    const armUnitOnBack = findSharedArmUnit(candidates.leftBackUnit, candidates.leftArmUnit)
+
+    const result = change('leftBackUnit', armUnitOnBack, baseAssembly)
+
+    expect(result.assembly.leftBackUnit).toBe(armUnitOnBack)
+    expect(result.remainingCandidates.leftArmUnit.some((p) => p.id === armUnitOnBack.id)).toBe(
+      false,
+    )
+  })
+
+  it('制約対象外のスロット変更では候補一覧を変更しない', () => {
+    const fcs = candidates.fcs[0]
+
+    const result = change('fcs', fcs, baseAssembly)
+
+    expect(result.assembly.fcs).toBe(fcs)
+    expect(result.remainingCandidates).toBe(candidates)
+  })
+})
+
+function createAssemblyFromCandidates(base: Candidates): Assembly {
+  return createAssembly({
+    rightArmUnit: pickEquippable(base.rightArmUnit),
+    leftArmUnit: pickEquippable(base.leftArmUnit),
+    rightBackUnit: pickEquippable(base.rightBackUnit),
+    leftBackUnit: pickEquippable(base.leftBackUnit),
+    head: base.head[0],
+    core: base.core[0],
+    arms: base.arms[0],
+    legs: base.legs[0],
+    booster: pickEquippable(base.booster),
+    fcs: base.fcs[0],
+    generator: base.generator[0],
+    expansion: base.expansion[0],
+  } as never)
+}
+
+function pickEquippable<T extends { classification: string }>(parts: readonly T[]): T {
+  const found = parts.find((part) => part.classification !== notEquipped)
+  if (!found) {
+    throw new Error('有効な候補が存在しません')
+  }
+
+  return found
+}
+
+function findSharedArmUnit<T extends { classification: string; id: string }>(
+  source: readonly T[],
+  target: readonly { id: string }[],
+): T {
+  const found = source.find(
+    (part) => part.classification !== notEquipped && target.some((candidate) => candidate.id === part.id),
+  )
+  if (!found) {
+    throw new Error('共有可能な武器が見つかりません')
+  }
+
+  return found
+}

--- a/packages/core/src/assembly/command/change-assembly.spec.ts
+++ b/packages/core/src/assembly/command/change-assembly.spec.ts
@@ -10,10 +10,13 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 describe('changeAssembly', () => {
   const change = changeAssemblyCommand(candidates)
+  const defaultBooster = pickEquippable(candidates.booster)
   let baseAssembly: Assembly
+  let baseCandidates: Candidates
 
   beforeEach(() => {
     baseAssembly = createAssemblyFromCandidates(candidates)
+    baseCandidates = candidates
   })
 
   it('タンク脚部を選択した場合はブースターを未装備にする', () => {
@@ -22,7 +25,7 @@ describe('changeAssembly', () => {
       throw new Error('タンク脚部の候補が見つかりません')
     }
 
-    const result = change('legs', tankLeg, baseAssembly)
+    const result = change('legs', tankLeg, baseAssembly, baseCandidates)
 
     expect(result.assembly.legs).toBe(tankLeg)
     expect(result.assembly.booster).toBe(boosterNotEquipped)
@@ -34,9 +37,63 @@ describe('changeAssembly', () => {
       throw new Error('タンク脚部の候補が見つかりません')
     }
 
-    const result = change('legs', tankLeg, baseAssembly)
+    const result = change('legs', tankLeg, baseAssembly, baseCandidates)
 
     expect(result.assembly.legs).toBe(tankLeg)
+    expect(result.remainingCandidates.booster).toEqual([boosterNotEquipped])
+  })
+
+  it('タンク以外の脚部を選択した場合は既存ブースターを維持し、候補一覧を戻す', () => {
+    const nonTankLeg = candidates.legs.find((leg) => leg.category !== tank)
+    if (!nonTankLeg) {
+      throw new Error('非タンク脚部の候補が見つかりません')
+    }
+
+    const result = change('legs', nonTankLeg, baseAssembly, {
+      ...baseCandidates,
+      booster: [boosterNotEquipped],
+    })
+
+    expect(result.assembly.legs).toBe(nonTankLeg)
+    expect(result.assembly.booster).toBe(baseAssembly.booster)
+    expect(result.remainingCandidates.booster).toEqual(candidates.booster)
+  })
+
+  it('タンク状態からタンク以外に戻す場合はデフォルトブースターを自動装備する', () => {
+    const tankLeg = candidates.legs.find((leg) => leg.category === tank)!
+    const tankAssembly = createAssembly({
+      ...baseAssembly,
+      legs: tankLeg,
+      booster: boosterNotEquipped,
+    })
+
+    const nonTankLeg = candidates.legs.find((leg) => leg.category !== tank)!
+    const result = change('legs', nonTankLeg, tankAssembly, {
+      ...baseCandidates,
+      booster: [boosterNotEquipped],
+    })
+
+    expect(result.assembly.legs).toBe(nonTankLeg)
+    expect(result.assembly.booster).toBe(defaultBooster)
+    expect(result.remainingCandidates.booster).toEqual(candidates.booster)
+  })
+
+  it('タンク状態で脚部以外を変更してもブースター候補は未装備のみのまま', () => {
+    const tankLeg = candidates.legs.find((leg) => leg.category === tank)!
+    const head = candidates.head[1]
+    const tankAssembly = createAssembly({
+      ...baseAssembly,
+      legs: tankLeg,
+      booster: boosterNotEquipped,
+    })
+    const tankCandidates: Candidates = {
+      ...baseCandidates,
+      booster: [boosterNotEquipped],
+    }
+
+    const result = change('head', head, tankAssembly, tankCandidates)
+
+    expect(result.assembly.head).toBe(head)
     expect(result.remainingCandidates.booster).toEqual([boosterNotEquipped])
   })
 
@@ -46,7 +103,7 @@ describe('changeAssembly', () => {
       candidates.rightBackUnit,
     )
 
-    const result = change('rightArmUnit', armUnit, baseAssembly)
+    const result = change('rightArmUnit', armUnit, baseAssembly, baseCandidates)
 
     expect(result.assembly.rightArmUnit).toBe(armUnit)
     expect(
@@ -60,7 +117,12 @@ describe('changeAssembly', () => {
       candidates.rightArmUnit,
     )
 
-    const result = change('rightBackUnit', armUnitOnBack, baseAssembly)
+    const result = change(
+      'rightBackUnit',
+      armUnitOnBack,
+      baseAssembly,
+      baseCandidates,
+    )
 
     expect(result.assembly.rightBackUnit).toBe(armUnitOnBack)
     expect(
@@ -76,7 +138,7 @@ describe('changeAssembly', () => {
       candidates.leftBackUnit,
     )
 
-    const result = change('leftArmUnit', armUnit, baseAssembly)
+    const result = change('leftArmUnit', armUnit, baseAssembly, baseCandidates)
 
     expect(result.assembly.leftArmUnit).toBe(armUnit)
     expect(
@@ -90,7 +152,12 @@ describe('changeAssembly', () => {
       candidates.leftArmUnit,
     )
 
-    const result = change('leftBackUnit', armUnitOnBack, baseAssembly)
+    const result = change(
+      'leftBackUnit',
+      armUnitOnBack,
+      baseAssembly,
+      baseCandidates,
+    )
 
     expect(result.assembly.leftBackUnit).toBe(armUnitOnBack)
     expect(
@@ -103,7 +170,7 @@ describe('changeAssembly', () => {
   it('制約対象外のスロット変更では候補一覧を変更しない', () => {
     const fcs = candidates.fcs[0]
 
-    const result = change('fcs', fcs, baseAssembly)
+    const result = change('fcs', fcs, baseAssembly, baseCandidates)
 
     expect(result.assembly.fcs).toBe(fcs)
     expect(result.remainingCandidates).toBe(candidates)

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -38,9 +38,10 @@ export const changeAssemblyCommand =
       }
     }
     if (key === 'legs' && isNotTankLegs(parts)) {
-      const booster = baseAssembly.booster.category !== 'not-equipped'
-        ? baseAssembly.booster
-        : initialCandidates.booster[0] as Booster
+      const booster =
+        baseAssembly.booster.category !== 'not-equipped'
+          ? baseAssembly.booster
+          : (initialCandidates.booster[0] as Booster)
       return {
         assembly: createAssembly({
           ...baseAssembly,
@@ -108,7 +109,9 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...baseCandidates,
           // 同じ武器を左手・左肩に装備は禁止
-          leftArmUnit: baseCandidates.leftArmUnit.filter((p) => p.id !== parts.id),
+          leftArmUnit: baseCandidates.leftArmUnit.filter(
+            (p) => p.id !== parts.id,
+          ),
         },
       }
     }

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -1,15 +1,15 @@
-import type { ArmUnit, LeftArmUnit } from "@ac6_assemble_tool/parts/arm-units"
-import type { Tank } from "@ac6_assemble_tool/parts/legs"
-import { boosterNotEquipped } from "@ac6_assemble_tool/parts/not-equipped"
-import { tank } from "@ac6_assemble_tool/parts/types/base/category"
+import type { ArmUnit, LeftArmUnit } from '@ac6_assemble_tool/parts/arm-units'
+import type { Tank } from '@ac6_assemble_tool/parts/legs'
+import { boosterNotEquipped } from '@ac6_assemble_tool/parts/not-equipped'
+import { tank } from '@ac6_assemble_tool/parts/types/base/category'
 import {
   armUnit as armUnitClassification,
   leftArmUnit as leftArmUnitClassification,
-} from "@ac6_assemble_tool/parts/types/base/classification"
-import type { ACParts } from "@ac6_assemble_tool/parts/types/base/types"
-import type { Candidates } from "@ac6_assemble_tool/parts/types/candidates"
+} from '@ac6_assemble_tool/parts/types/base/classification'
+import type { ACParts } from '@ac6_assemble_tool/parts/types/base/types'
+import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 
-import { createAssembly, type Assembly, type AssemblyKey } from "../assembly"
+import { createAssembly, type Assembly, type AssemblyKey } from '../assembly'
 
 interface ResultChangeAssembly {
   assembly: Assembly
@@ -17,7 +17,11 @@ interface ResultChangeAssembly {
 }
 export const changeAssemblyCommand =
   (candidates: Candidates) =>
-  (key: AssemblyKey, parts: ACParts, baseAssembly: Assembly): ResultChangeAssembly => {
+  (
+    key: AssemblyKey,
+    parts: ACParts,
+    baseAssembly: Assembly,
+  ): ResultChangeAssembly => {
     if (isTankLegs(parts)) {
       return {
         assembly: createAssembly({
@@ -28,7 +32,7 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...candidates,
           booster: [boosterNotEquipped],
-        }
+        },
       }
     }
 
@@ -41,7 +45,9 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...candidates,
           // 同じ武器を右手・右肩に装備は禁止
-          rightBackUnit: candidates.rightBackUnit.filter(p => p.id !== parts.id),
+          rightBackUnit: candidates.rightBackUnit.filter(
+            (p) => p.id !== parts.id,
+          ),
         },
       }
     }
@@ -54,7 +60,9 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...candidates,
           // 同じ武器を右手・右肩に装備は禁止
-          rightArmUnit: candidates.rightArmUnit.filter(p => p.id !== parts.id),
+          rightArmUnit: candidates.rightArmUnit.filter(
+            (p) => p.id !== parts.id,
+          ),
         },
       }
     }
@@ -67,7 +75,9 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...candidates,
           // 同じ武器を左手・左肩に装備は禁止
-          leftBackUnit: candidates.leftBackUnit.filter(p => p.id !== parts.id),
+          leftBackUnit: candidates.leftBackUnit.filter(
+            (p) => p.id !== parts.id,
+          ),
         },
       }
     }
@@ -80,7 +90,7 @@ export const changeAssemblyCommand =
         remainingCandidates: {
           ...candidates,
           // 同じ武器を左手・左肩に装備は禁止
-          leftArmUnit: candidates.leftArmUnit.filter(p => p.id !== parts.id),
+          leftArmUnit: candidates.leftArmUnit.filter((p) => p.id !== parts.id),
         },
       }
     }
@@ -99,7 +109,7 @@ function isTankLegs(parts: ACParts): parts is Tank {
 }
 function isArmUnit(parts: ACParts): parts is ArmUnit | LeftArmUnit {
   return isRightArmUnit(parts) || isLeftArmUnit(parts)
-} 
+}
 function isRightArmUnit(parts: ACParts): parts is ArmUnit {
   return parts.classification === armUnitClassification
 }

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -1,0 +1,108 @@
+import type { ArmUnit, LeftArmUnit } from "@ac6_assemble_tool/parts/arm-units"
+import type { Tank } from "@ac6_assemble_tool/parts/legs"
+import { boosterNotEquipped } from "@ac6_assemble_tool/parts/not-equipped"
+import { tank } from "@ac6_assemble_tool/parts/types/base/category"
+import {
+  armUnit as armUnitClassification,
+  leftArmUnit as leftArmUnitClassification,
+} from "@ac6_assemble_tool/parts/types/base/classification"
+import type { ACParts } from "@ac6_assemble_tool/parts/types/base/types"
+import type { Candidates } from "@ac6_assemble_tool/parts/types/candidates"
+
+import { createAssembly, type Assembly, type AssemblyKey } from "../assembly"
+
+interface ResultChangeAssembly {
+  assembly: Assembly
+  remainingCandidates: Candidates
+}
+export const changeAssemblyCommand =
+  (candidates: Candidates) =>
+  (key: AssemblyKey, parts: ACParts, baseAssembly: Assembly): ResultChangeAssembly => {
+    if (isTankLegs(parts)) {
+      return {
+        assembly: createAssembly({
+          ...baseAssembly,
+          legs: parts,
+          booster: boosterNotEquipped,
+        }),
+        remainingCandidates: {
+          ...candidates,
+          booster: [boosterNotEquipped],
+        }
+      }
+    }
+
+    if (key === 'rightArmUnit' && isRightArmUnit(parts)) {
+      return {
+        assembly: createAssembly({
+          ...baseAssembly,
+          rightArmUnit: parts,
+        }),
+        remainingCandidates: {
+          ...candidates,
+          // 同じ武器を右手・右肩に装備は禁止
+          rightBackUnit: candidates.rightBackUnit.filter(p => p.id !== parts.id),
+        },
+      }
+    }
+    if (key === 'rightBackUnit' && isRightArmUnit(parts)) {
+      return {
+        assembly: createAssembly({
+          ...baseAssembly,
+          [key]: parts,
+        }),
+        remainingCandidates: {
+          ...candidates,
+          // 同じ武器を右手・右肩に装備は禁止
+          rightArmUnit: candidates.rightArmUnit.filter(p => p.id !== parts.id),
+        },
+      }
+    }
+    if (key === 'leftArmUnit' && isArmUnit(parts)) {
+      return {
+        assembly: createAssembly({
+          ...baseAssembly,
+          [key]: parts,
+        }),
+        remainingCandidates: {
+          ...candidates,
+          // 同じ武器を左手・左肩に装備は禁止
+          leftBackUnit: candidates.leftBackUnit.filter(p => p.id !== parts.id),
+        },
+      }
+    }
+    if (key === 'leftBackUnit' && isArmUnit(parts)) {
+      return {
+        assembly: createAssembly({
+          ...baseAssembly,
+          [key]: parts,
+        }),
+        remainingCandidates: {
+          ...candidates,
+          // 同じ武器を左手・左肩に装備は禁止
+          leftArmUnit: candidates.leftArmUnit.filter(p => p.id !== parts.id),
+        },
+      }
+    }
+
+    return {
+      assembly: createAssembly({
+        ...baseAssembly,
+        [key]: parts,
+      }),
+      remainingCandidates: candidates,
+    }
+  }
+
+function isTankLegs(parts: ACParts): parts is Tank {
+  return parts.category === tank
+}
+function isArmUnit(parts: ACParts): parts is ArmUnit | LeftArmUnit {
+  return isRightArmUnit(parts) || isLeftArmUnit(parts)
+} 
+function isRightArmUnit(parts: ACParts): parts is ArmUnit {
+  return parts.classification === armUnitClassification
+}
+function isLeftArmUnit(parts: ACParts): parts is LeftArmUnit {
+  return parts.classification === leftArmUnitClassification
+}

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -60,7 +60,8 @@ export const changeAssemblyCommand =
     if (isRightArmBackKey(key) && isRightArmUnit(parts)) {
       return changeArmBackPair({
         targetKey: key,
-        counterpartKey: key === 'rightArmUnit' ? 'rightBackUnit' : 'rightArmUnit',
+        counterpartKey:
+          key === 'rightArmUnit' ? 'rightBackUnit' : 'rightArmUnit',
         parts,
         baseAssembly,
         baseCandidates,
@@ -101,9 +102,7 @@ function isLeftArmUnit(parts: ACParts): parts is LeftArmUnit {
   return parts.classification === leftArmUnitClassification
 }
 
-function getDefaultBooster(
-  boosterCandidates: Candidates['booster'],
-): Booster {
+function getDefaultBooster(boosterCandidates: Candidates['booster']): Booster {
   const booster = boosterCandidates.find(
     (candidate): candidate is Booster =>
       candidate.classification === boosterClassification,
@@ -153,10 +152,14 @@ function changeArmBackPair<K extends ArmBackKey>({
   }
 }
 
-function isRightArmBackKey(key: AssemblyKey): key is 'rightArmUnit' | 'rightBackUnit' {
+function isRightArmBackKey(
+  key: AssemblyKey,
+): key is 'rightArmUnit' | 'rightBackUnit' {
   return key === 'rightArmUnit' || key === 'rightBackUnit'
 }
 
-function isLeftArmBackKey(key: AssemblyKey): key is 'leftArmUnit' | 'leftBackUnit' {
+function isLeftArmBackKey(
+  key: AssemblyKey,
+): key is 'leftArmUnit' | 'leftBackUnit' {
   return key === 'leftArmUnit' || key === 'leftBackUnit'
 }

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -22,7 +22,7 @@ export const changeAssemblyCommand =
     parts: ACParts,
     baseAssembly: Assembly,
   ): ResultChangeAssembly => {
-    if (isTankLegs(parts)) {
+    if (key === 'legs' && isTankLegs(parts)) {
       return {
         assembly: createAssembly({
           ...baseAssembly,

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -55,65 +55,23 @@ export const changeAssemblyCommand =
       }
     }
 
-    if (key === 'rightArmUnit' && isRightArmUnit(parts)) {
-      return {
-        assembly: createAssembly({
-          ...baseAssembly,
-          rightArmUnit: parts,
-        }),
-        remainingCandidates: {
-          ...baseCandidates,
-          // 同じ武器を右手・右肩に装備は禁止
-          rightBackUnit: baseCandidates.rightBackUnit.filter(
-            (p) => p.id !== parts.id,
-          ),
-        },
-      }
+    if (isRightArmBackKey(key) && isRightArmUnit(parts)) {
+      return changeArmBackPair({
+        targetKey: key,
+        counterpartKey: key === 'rightArmUnit' ? 'rightBackUnit' : 'rightArmUnit',
+        parts,
+        baseAssembly,
+        baseCandidates,
+      })
     }
-    if (key === 'rightBackUnit' && isRightArmUnit(parts)) {
-      return {
-        assembly: createAssembly({
-          ...baseAssembly,
-          [key]: parts,
-        }),
-        remainingCandidates: {
-          ...baseCandidates,
-          // 同じ武器を右手・右肩に装備は禁止
-          rightArmUnit: baseCandidates.rightArmUnit.filter(
-            (p) => p.id !== parts.id,
-          ),
-        },
-      }
-    }
-    if (key === 'leftArmUnit' && isArmUnit(parts)) {
-      return {
-        assembly: createAssembly({
-          ...baseAssembly,
-          [key]: parts,
-        }),
-        remainingCandidates: {
-          ...baseCandidates,
-          // 同じ武器を左手・左肩に装備は禁止
-          leftBackUnit: baseCandidates.leftBackUnit.filter(
-            (p) => p.id !== parts.id,
-          ),
-        },
-      }
-    }
-    if (key === 'leftBackUnit' && isArmUnit(parts)) {
-      return {
-        assembly: createAssembly({
-          ...baseAssembly,
-          [key]: parts,
-        }),
-        remainingCandidates: {
-          ...baseCandidates,
-          // 同じ武器を左手・左肩に装備は禁止
-          leftArmUnit: baseCandidates.leftArmUnit.filter(
-            (p) => p.id !== parts.id,
-          ),
-        },
-      }
+    if (isLeftArmBackKey(key) && isArmUnit(parts)) {
+      return changeArmBackPair({
+        targetKey: key,
+        counterpartKey: key === 'leftArmUnit' ? 'leftBackUnit' : 'leftArmUnit',
+        parts,
+        baseAssembly,
+        baseCandidates,
+      })
     }
 
     return {
@@ -139,4 +97,49 @@ function isRightArmUnit(parts: ACParts): parts is ArmUnit {
 }
 function isLeftArmUnit(parts: ACParts): parts is LeftArmUnit {
   return parts.classification === leftArmUnitClassification
+}
+
+type ArmBackKey =
+  | 'rightArmUnit'
+  | 'rightBackUnit'
+  | 'leftArmUnit'
+  | 'leftBackUnit'
+
+type ChangeArmBackPairArgs<TargetKey extends ArmBackKey> = {
+  targetKey: TargetKey
+  counterpartKey: TargetKey extends 'rightArmUnit' | 'rightBackUnit'
+    ? 'rightArmUnit' | 'rightBackUnit'
+    : 'leftArmUnit' | 'leftBackUnit'
+  parts: ArmUnit | LeftArmUnit
+  baseAssembly: Assembly
+  baseCandidates: Candidates
+}
+
+function changeArmBackPair<K extends ArmBackKey>({
+  targetKey,
+  counterpartKey,
+  parts,
+  baseAssembly,
+  baseCandidates,
+}: ChangeArmBackPairArgs<K>): ResultChangeAssembly {
+  return {
+    assembly: createAssembly({
+      ...baseAssembly,
+      [targetKey]: parts,
+    }),
+    remainingCandidates: {
+      ...baseCandidates,
+      [counterpartKey]: baseCandidates[counterpartKey].filter(
+        (candidate) => candidate.id !== parts.id,
+      ),
+    },
+  }
+}
+
+function isRightArmBackKey(key: AssemblyKey): key is 'rightArmUnit' | 'rightBackUnit' {
+  return key === 'rightArmUnit' || key === 'rightBackUnit'
+}
+
+function isLeftArmBackKey(key: AssemblyKey): key is 'leftArmUnit' | 'leftBackUnit' {
+  return key === 'leftArmUnit' || key === 'leftBackUnit'
 }

--- a/packages/core/src/assembly/command/change-assembly.ts
+++ b/packages/core/src/assembly/command/change-assembly.ts
@@ -5,7 +5,9 @@ import { boosterNotEquipped } from '@ac6_assemble_tool/parts/not-equipped'
 import { tank } from '@ac6_assemble_tool/parts/types/base/category'
 import {
   armUnit as armUnitClassification,
+  booster as boosterClassification,
   leftArmUnit as leftArmUnitClassification,
+  notEquipped as notEquippedClassification,
 } from '@ac6_assemble_tool/parts/types/base/classification'
 import type { ACParts } from '@ac6_assemble_tool/parts/types/base/types'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
@@ -39,9 +41,9 @@ export const changeAssemblyCommand =
     }
     if (key === 'legs' && isNotTankLegs(parts)) {
       const booster =
-        baseAssembly.booster.category !== 'not-equipped'
+        baseAssembly.booster.classification !== notEquippedClassification
           ? baseAssembly.booster
-          : (initialCandidates.booster[0] as Booster)
+          : getDefaultBooster(initialCandidates.booster)
       return {
         assembly: createAssembly({
           ...baseAssembly,
@@ -97,6 +99,21 @@ function isRightArmUnit(parts: ACParts): parts is ArmUnit {
 }
 function isLeftArmUnit(parts: ACParts): parts is LeftArmUnit {
   return parts.classification === leftArmUnitClassification
+}
+
+function getDefaultBooster(
+  boosterCandidates: Candidates['booster'],
+): Booster {
+  const booster = boosterCandidates.find(
+    (candidate): candidate is Booster =>
+      candidate.classification === boosterClassification,
+  )
+
+  if (!booster) {
+    throw new Error('ブースター候補が見つかりません')
+  }
+
+  return booster
 }
 
 type ArmBackKey =

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -86,7 +86,8 @@
 
   let initialCandidates: Candidates = partsPoolState.candidates
   let candidates: Candidates = partsPoolState.candidates
-  let changeAssembly = changeAssemblyCommand(initialCandidates)
+  // changeAssemblyはinitialCandidatesの変更に追従するようリアクティブに定義
+  $: changeAssembly = changeAssemblyCommand(initialCandidates)
   let lockedParts: LockedParts = LockedParts.empty
   let randomAssembly = RandomAssembly.init({ limit: tryLimit })
 

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -14,6 +14,7 @@
     spaceByWord,
     createAssembly,
   } from '@ac6_assemble_tool/core/assembly/assembly'
+  import { changeAssemblyCommand } from '@ac6_assemble_tool/core/assembly/command/change-assembly'
   import { LockedParts } from '@ac6_assemble_tool/core/assembly/random/lock'
   import { RandomAssembly } from '@ac6_assemble_tool/core/assembly/random/random-assembly'
   import {
@@ -85,6 +86,7 @@
 
   let initialCandidates: Candidates = partsPoolState.candidates
   let candidates: Candidates = partsPoolState.candidates
+  let changeAssembly = changeAssemblyCommand(initialCandidates)
   let lockedParts: LockedParts = LockedParts.empty
   let randomAssembly = RandomAssembly.init({ limit: tryLimit })
 
@@ -149,9 +151,10 @@
   }
 
   const onChangeParts = ({ detail }: CustomEvent<ChangePartsEvent>) => {
-    // @ts-expect-error TS2590
-    assembly[detail.id] = detail.selected
-    assembly = assembly
+    const result = changeAssembly(detail.id, detail.selected, assembly)
+
+    assembly = result.assembly
+    candidates = result.remainingCandidates
   }
   const onRandom = ({ detail }: CustomEvent<AssembleRandomly>) => {
     assembly = detail.assembly

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -151,7 +151,7 @@
   }
 
   const onChangeParts = ({ detail }: CustomEvent<ChangePartsEvent>) => {
-    const result = changeAssembly(detail.id, detail.selected, assembly)
+    const result = changeAssembly(detail.id, detail.selected, assembly, candidates)
 
     assembly = result.assembly
     candidates = result.remainingCandidates

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -151,7 +151,12 @@
   }
 
   const onChangeParts = ({ detail }: CustomEvent<ChangePartsEvent>) => {
-    const result = changeAssembly(detail.id, detail.selected, assembly, candidates)
+    const result = changeAssembly(
+      detail.id,
+      detail.selected,
+      assembly,
+      candidates,
+    )
 
     assembly = result.assembly
     candidates = result.remainingCandidates

--- a/packages/web/src/lib/view/index/random/range/CoamRangeSlider.svelte
+++ b/packages/web/src/lib/view/index/random/range/CoamRangeSlider.svelte
@@ -52,7 +52,7 @@
 <RangeSlider
   id="coam"
   class={$$props.class}
-  label={$i18n.t('range.coam.label', { ns: 'random' })}
+  label={$i18n.t('random:range.coam.label')}
   {max}
   {value}
   step={1000}

--- a/packages/web/src/lib/view/index/random/range/LoadRangeSlider.svelte
+++ b/packages/web/src/lib/view/index/random/range/LoadRangeSlider.svelte
@@ -85,7 +85,7 @@
 <RangeSlider
   id="load"
   class={$$props.class}
-  label={$i18n.t('range.load.label', { ns: 'random' })}
+  label={$i18n.t('random:range.load.label')}
   {max}
   {min}
   {value}
@@ -119,7 +119,7 @@
         {/if}
       </DropdownItem>
       <DropdownItem on:click={onSetLoadLimit}>
-        {$i18n.t('range.load.applyCurrentLegsLoadLimit', { ns: 'random' })}
+        {$i18n.t('random:range.load.applyCurrentLegsLoadLimit')}
       </DropdownItem>
     </DropdownMenu>
   </Dropdown>


### PR DESCRIPTION
## このPRの目的

タンク足選択時は以下の状態になるべき

- ブースターがNotEquippedになる
- ブースターの選択肢がNotEquippedのみになる

また、右手と右肩、左手と左肩に同じ武器は装備できないように候補から外されるべき

## 主な変更点

- タンク足選択時、ブースターの選択状態を強制変更 + 候補を強制更新

## レビュー観点

-

## 関連Issue / ADR

- Issue:
    - #932
    - #449 
- ADR: #

## チェックリスト

- [ ] 関連するIssueに紐づけた
- [ ] CIが成功している
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した
