### PR TITLE
Remove Google Tag Manager

### DIFF
--- a/.changeset/bumpy-lemons-fry.md
+++ b/.changeset/bumpy-lemons-fry.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+remove Google Tag Manager
+  

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
       "repo": "tooppoo/ac6_assemble_tool"
     }
   ],
-  "commit": false,
+  "commit": true,
   "fixed": [],
   "linked": [],
   "access": "restricted",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/core
 
 ## 1.2.1
+
 ### Patch Changes
-
-
 
 - [#934](https://github.com/tooppoo/ac6_assemble_tool/pull/934) [`7988eeb`](https://github.com/tooppoo/ac6_assemble_tool/commit/7988eeb543bac6825155f88887c8e4d9b149045f) Thanks [@tooppoo](https://github.com/tooppoo)! - fix bug when tank legs are selected
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/web
 
 ## 3.1.2
+
 ### Patch Changes
-
-
 
 - [#934](https://github.com/tooppoo/ac6_assemble_tool/pull/934) [`7988eeb`](https://github.com/tooppoo/ac6_assemble_tool/commit/7988eeb543bac6825155f88887c8e4d9b149045f) Thanks [@tooppoo](https://github.com/tooppoo)! - fix bug when tank legs are selected
 

--- a/packages/web/src/app.html
+++ b/packages/web/src/app.html
@@ -1,30 +1,11 @@
 <!doctype html>
 <html lang="ja" data-bs-theme="dark">
   <head prefix="og: https://ogp.me/ns#">
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({
-          'gtm.start': new Date().getTime(),
-          event: 'gtm.js',
-        })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WVNXH6Q4')
-    </script>
-    <!-- End Google Tag Manager -->
-
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     %sveltekit.head%
   </head>
 
-  <!-- Google tag (gtag.js) -->
   <!-- GA -->
   <script
     async
@@ -46,15 +27,4 @@
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
-
-  <!-- Google Tag Manager (noscript) -->
-  <noscript
-    ><iframe
-      src="https://www.googletagmanager.com/ns.html?id=GTM-WVNXH6Q4"
-      height="0"
-      width="0"
-      style="display: none; visibility: hidden"
-    ></iframe
-  ></noscript>
-  <!-- End Google Tag Manager (noscript) -->
 </html>


### PR DESCRIPTION
## このPRの目的

- 現状、GTMを使っていないので、削除して軽量化したい
- タグをまとめて管理したいなら、自分でコンポーネント化すれば良い

## 主な変更点

- GTM削除
