### PR TITLE
テストエラー修正

### DIFF
--- a/packages/core/src/assembly/random/random-assembly.spec.ts
+++ b/packages/core/src/assembly/random/random-assembly.spec.ts
@@ -198,6 +198,7 @@ describe(RandomAssembly.name, () => {
     })
 
     afterEach(() => {
+      vi.clearAllMocks()
       vi.restoreAllMocks()
     })
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/web
 
 ## 3.1.3
+
 ### Patch Changes
-
-
 
 - [#936](https://github.com/tooppoo/ac6_assemble_tool/pull/936) [`8c85fa3`](https://github.com/tooppoo/ac6_assemble_tool/commit/8c85fa30632a4c588eb7bfa030ce55775866bb90) Thanks [@tooppoo](https://github.com/tooppoo)! - remove Google Tag Manager
 

--- a/packages/web/src/lib/view/index/interaction/error-message.spec.ts
+++ b/packages/web/src/lib/view/index/interaction/error-message.spec.ts
@@ -28,6 +28,7 @@ describe(assemblyErrorMessage.name, () => {
     }
   })
   afterEach(() => {
+    vi.clearAllMocks()
     vi.restoreAllMocks()
   })
 
@@ -121,10 +122,6 @@ describe(assemblyErrorMessage.name, () => {
                 adjustable: false,
               }),
             )
-
-        afterEach(() => {
-          vi.restoreAllMocks()
-        })
         it.prop([
           fc.array(genTotalLoadNotOverMax(), load),
           fc.array(genTotalCoamNotOverMax(), coam),
@@ -183,9 +180,8 @@ describe(assemblyErrorMessage.name, () => {
               'times',
             )
 
-            // it.prop で実行する場合、
-            // beforeEachの前に次のプロパティが実行される模様
-            vi.restoreAllMocks()
+            // fast-check の各試行間でもモック呼び出し回数をリセットする
+            mock.mockClear()
           },
         )
       },

--- a/packages/web/src/lib/view/index/parts-pool.spec.ts
+++ b/packages/web/src/lib/view/index/parts-pool.spec.ts
@@ -9,6 +9,7 @@ describe('parts-pool', () => {
   const baseCandidates = regulation.candidates
 
   afterEach(() => {
+    vi.clearAllMocks()
     vi.restoreAllMocks()
   })
 

--- a/packages/web/src/lib/view/parts-list/state/view-mode.spec.ts
+++ b/packages/web/src/lib/view/parts-list/state/view-mode.spec.ts
@@ -6,6 +6,7 @@ import { loadViewMode, saveViewMode } from './view-mode'
 describe('state/view-mode', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.clearAllMocks()
     vi.restoreAllMocks()
     if (typeof localStorage !== 'undefined') {
       localStorage.clear()

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     environment: 'jsdom',
+    pool: 'threads',
     coverage: {
       reporter: ['text', 'json'],
       exclude: [

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,8 +1,11 @@
 import { svelteTesting } from '@testing-library/svelte/vite'
+import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [svelteTesting()],
+  // SvelteファイルとSvelteKitの仮想モジュール($app/*等)を解決するため、
+  // Vitest側でもSvelteKitプラグインを有効化する。
+  plugins: [sveltekit(), svelteTesting()],
   resolve: {
     alias: {
       $lib: '/src/lib',

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     environment: 'jsdom',
-    pool: 'threads',
     coverage: {
       reporter: ['text', 'json'],
       exclude: [

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,5 +1,5 @@
-import { svelteTesting } from '@testing-library/svelte/vite'
 import { sveltekit } from '@sveltejs/kit/vite'
+import { svelteTesting } from '@testing-library/svelte/vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
## このPRの目的

vitest v4への更新でモックの利用方法が変わったため、一部のテストが失敗するようになったため

## 主な変更点

モックのリセット方法修正

## レビュー観点

-

## 関連Issue / ADR

- Issue: #
- ADR: #

## チェックリスト

- [ ] 関連するIssueに紐づけた
- [ ] CIが成功している
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した
