### PR TITLE
setup GitHub pages sitemap

### DIFF
--- a/.changeset/happy-clubs-try.md
+++ b/.changeset/happy-clubs-try.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+setup github pages sitemap
+  

--- a/packages/github-pages/sitemap.xml
+++ b/packages/github-pages/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tooppoo.github.io/ac6_assemble_tool/</loc>
+    <lastmod>2025-12-05</lastmod>
+  </url>
+  <url>
+  
+    <loc>https://tooppoo.github.io/ac6_assemble_tool/parts-list</loc>
+    <lastmod>2025-12-05</lastmod>
+  </url>
+</urlset>

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/web
 
 ## 3.2.2
+
 ### Patch Changes
-
-
 
 - [#958](https://github.com/tooppoo/ac6_assemble_tool/pull/958) [`a9c0f76`](https://github.com/tooppoo/ac6_assemble_tool/commit/a9c0f768bf5e96ba7c31e07d57031d09de7cfa72) Thanks [@tooppoo](https://github.com/tooppoo)! - add text on each app page, and update footer layout
 

--- a/packages/web/src/lib/components/layout/CollapseText.svelte
+++ b/packages/web/src/lib/components/layout/CollapseText.svelte
@@ -2,17 +2,15 @@
   import type { Snippet } from 'svelte'
 
   interface Props {
-    summary?: string
+    summary: string
     children: Snippet
   }
 
-  let { summary = '', children }: Props = $props()
+  let { summary, children }: Props = $props()
 </script>
 
 <details>
-  {#if summary.length > 0}
-    <summary>{summary}</summary>
-  {/if}
+  <summary>{summary}</summary>
 
   {@render children()}
 </details>


### PR DESCRIPTION
## このPRの目的

github pages はgoogleインデックスに登録されているので、それを利用してパーツリストへの流入経路を作る

## 主な変更点

リダイレクトのみを行う `/parts-list` を配置する

## 関連Issue / ADR

- Issue: #845 
- ADR: #
