### PR TITLE
Reuse GitHub pages

### DIFF
--- a/.changeset/smart-memes-peel.md
+++ b/.changeset/smart-memes-peel.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+deploy both of github pages and cloudflare pages
+  

--- a/.github/workflows/web-create-release.yml
+++ b/.github/workflows/web-create-release.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      # github pages artifact
+      # 301リダイレクトでドメイン評価がったら削除
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: packages/web/dist
+
       # deploy
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
@@ -60,3 +69,17 @@ jobs:
         with:
           tag_name: "web/v${{ steps.version.outputs.version }}"
           generate_release_notes: true
+
+  deploy-github-pages:
+    needs: create-release
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## このPRの目的

再び github pages をエントリポイントとして、Google評価が移るのを待つ

## 主な変更点

- github pagesとcloudflare pagesで並行デプロイ
- 独自ドメインはgithub pagesにのみ設定
- Google評価が映ったら、github pagesは再びstaticなクライアントリダイレクトにする

## 関連Issue / ADR

- Issue: #845 
- ADR: #
