### PR TITLE
レイアウト調整と自動デプロイフローの拡張

### DIFF
--- a/.changeset/plenty-ducks-sneeze.md
+++ b/.changeset/plenty-ducks-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+fix contents layout
+  

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Use this agent when you have just completed writing or modifying a logical chunk of code and need it reviewed for quality, adherence to project standards, and potential issues. This agent should be invoked proactively after implementing features, fixing bugs, or making significant changes. Examples:\n\n- User: "I've just implemented the user authentication module"\n  Assistant: "Let me use the code-reviewer agent to review the authentication code you've written."\n  [Uses Task tool to launch code-reviewer agent]\n\n- User: "Here's the new API endpoint for fetching parts by unique ID"\n  Assistant: "I'll have the code-reviewer agent examine this endpoint implementation for compliance with our standards."\n  [Uses Task tool to launch code-reviewer agent]\n\n- User: "I've refactored the database connection logic"\n  Assistant: "Let me invoke the code-reviewer agent to ensure the refactoring maintains quality and follows our patterns."\n  [Uses Task tool to launch code-reviewer agent]
-model: sonnet
+model: haiku
 color: green
 ---
 

--- a/.github/workflows/web-auto-deploy-deps.yml
+++ b/.github/workflows/web-auto-deploy-deps.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      is_dep_update: ${{ steps.check-deps.outputs.is_dep_update }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -58,6 +60,16 @@ jobs:
         if: steps.check-deps.outputs.is_dep_update == 'true'
         run: pnpm run build
 
+      - name: Configure GitHub Pages
+        if: steps.check-deps.outputs.is_dep_update == 'true'
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload GitHub Pages artifact
+        if: steps.check-deps.outputs.is_dep_update == 'true'
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: packages/web/dist
+
       - name: Deploy to Cloudflare Pages
         if: steps.check-deps.outputs.is_dep_update == 'true'
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
@@ -65,3 +77,19 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy packages/web/dist --project-name=ac6-assemble-tool --commit-dirty=true
+
+  # google評価以降後は削除
+  deploy-github-pages:
+    needs: check-and-deploy
+    if: needs.check-and-deploy.outputs.is_dep_update == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/web-auto-deploy-deps.yml
+++ b/.github/workflows/web-auto-deploy-deps.yml
@@ -78,7 +78,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy packages/web/dist --project-name=ac6-assemble-tool --commit-dirty=true
 
-  # google評価以降後は削除
+  # google評価移行後は削除
   deploy-github-pages:
     needs: check-and-deploy
     if: needs.check-and-deploy.outputs.is_dep_update == 'true'

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,16 +1,14 @@
 # @ac6_assemble_tool/web
 
 ## 3.2.4
+
 ### Patch Changes
-
-
 
 - [#962](https://github.com/tooppoo/ac6_assemble_tool/pull/962) [`1ed9e9c`](https://github.com/tooppoo/ac6_assemble_tool/commit/1ed9e9c40b916196b91720157df21355971990ee) Thanks [@tooppoo](https://github.com/tooppoo)! - deploy both of github pages and cloudflare pages
 
 ## 3.2.3
+
 ### Patch Changes
-
-
 
 - [#960](https://github.com/tooppoo/ac6_assemble_tool/pull/960) [`de39e64`](https://github.com/tooppoo/ac6_assemble_tool/commit/de39e64e24536eba28c52cf1d232927724accf4c) Thanks [@tooppoo](https://github.com/tooppoo)! - setup github pages sitemap
 

--- a/packages/web/src/lib/components/layout/CollapseText.svelte
+++ b/packages/web/src/lib/components/layout/CollapseText.svelte
@@ -3,13 +3,14 @@
 
   interface Props {
     summary: string
+    class?: string
     children: Snippet
   }
 
-  let { summary, children }: Props = $props()
+  let { summary, class: className, children }: Props = $props()
 </script>
 
-<details>
+<details class={className}>
   <summary>{summary}</summary>
 
   {@render children()}

--- a/packages/web/src/lib/components/layout/footer/FooterSection.svelte
+++ b/packages/web/src/lib/components/layout/footer/FooterSection.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { type Snippet } from 'svelte'
+
+  interface Props {
+    caption: string
+    class?: string
+    children: Snippet
+  }
+  let { caption, class: className, children }: Props = $props()
+</script>
+
+<section class="text-start {className}">
+  <div class="fs-5">{caption}</div>
+  {@render children()}
+</section>

--- a/packages/web/src/lib/components/list/FlushList.svelte
+++ b/packages/web/src/lib/components/list/FlushList.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { type Snippet } from 'svelte'
+
+  interface Props {
+    children: Snippet
+  }
+  let { children }: Props = $props()
+</script>
+
+<ul class="list-group list-group-flush">
+  {@render children()}
+</ul>

--- a/packages/web/src/lib/components/list/ListItem.svelte
+++ b/packages/web/src/lib/components/list/ListItem.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { type Snippet } from 'svelte'
+
+  interface Props {
+    children: Snippet
+  }
+  let { children }: Props = $props()
+</script>
+
+<li class="list-group-item">
+  {@render children()}
+</li>

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -343,7 +343,10 @@
     <ReportList {assembly} />
   </ToolSection>
 
-  <CollapseText summary={$i18n.t('page/index:aboutSection.summary')}>
+  <CollapseText
+    summary={$i18n.t('page/index:aboutSection.summary')}
+    class="my-4 text-start"
+  >
     <p>{$i18n.t('page/index:aboutSection.body.p1')}</p>
     <p>{$i18n.t('page/index:aboutSection.body.p2')}</p>
     <p>{$i18n.t('page/index:aboutSection.body.p3')}</p>

--- a/packages/web/src/lib/view/parts-list/PartsListView.svelte
+++ b/packages/web/src/lib/view/parts-list/PartsListView.svelte
@@ -395,7 +395,7 @@
   }
 </script>
 
-<article class="parts-list-view text-center">
+<article class="parts-list-view">
   <div class="py-1">
     <SlotSelector {currentSlot} onslotchange={handleSlotChange} />
   </div>
@@ -459,7 +459,10 @@
     />
   </div>
 
-  <CollapseText summary={$i18n.t('page/parts-list:aboutSection.summary')}>
+  <CollapseText
+    summary={$i18n.t('page/parts-list:aboutSection.summary')}
+    class="my-4 text-start"
+  >
     <p>{$i18n.t('page/parts-list:aboutSection.body.p1')}</p>
     <p>{$i18n.t('page/parts-list:aboutSection.body.p2')}</p>
     <p>{$i18n.t('page/parts-list:aboutSection.body.p3')}</p>

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -172,10 +172,11 @@
             <a href={`/about${pageQuery}`}>About</a>
           </ListItem>
           <ListItem>
-            <a href={`/rule${pageQuery}`}>Terms of Use</a>
+            <a href={`/rule${pageQuery}`} rel="terms-of-service">Terms of Use</a
+            >
           </ListItem>
           <ListItem>
-            <a href={`/privacy${pageQuery}`}>Privacy</a>
+            <a href={`/privacy${pageQuery}`} rel="privacy-policy">Privacy</a>
           </ListItem>
         </FlushList>
       </FooterSection>
@@ -206,6 +207,7 @@
             <a
               id="link-to-website"
               href="https://philomagi.dev"
+              rel="external noopener noreferrer"
               target="_blank"
             >
               https://philomagi.dev

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import './app.scss'
   import { appUrl, publicPath } from '$lib/app-url'
+  import FooterSection from '$lib/components/layout/footer/FooterSection.svelte'
   import ToolSection from '$lib/components/layout/ToolSection.svelte'
+  import FlushList from '$lib/components/list/FlushList.svelte'
+  import ListItem from '$lib/components/list/ListItem.svelte'
   import Margin from '$lib/components/spacing/Margin.svelte'
   import i18n from '$lib/i18n/define'
   import { extractChars } from '$lib/i18n/extract-chars'
@@ -151,60 +154,68 @@
   <hr class="my-3" />
 
   <footer class="container text-center">
-    <div class="row align-items-center">
-      <section class="col mb-3">
-        <div>
-          <a href={`/${pageQuery}`}>ASSEMBLE TOOL</a>
-        </div>
-        <div>
-          <a href={`/parts-list${pageQuery}`}>PARTS LIST</a>
-        </div>
-      </section>
+    <div class="row align-items-start">
+      <FooterSection caption="TOOLS" class="col">
+        <FlushList>
+          <ListItem>
+            <a href={`/${pageQuery}`}>ASSEMBLY TOOL</a>
+          </ListItem>
+          <ListItem>
+            <a href={`/parts-list${pageQuery}`}>PARTS LIST</a>
+          </ListItem>
+        </FlushList>
+      </FooterSection>
 
-      <section class="col mb-3">
-        <div>
-          <a href={`/about${pageQuery}`}>About</a>
-        </div>
-        <div>
-          <a href={`/rule${pageQuery}`}>Terms of Use</a>
-        </div>
-        <div>
-          <a href={`/privacy${pageQuery}`}>Privacy Policy</a>
-        </div>
-      </section>
+      <FooterSection caption="CONTENTS" class="col">
+        <FlushList>
+          <ListItem>
+            <a href={`/about${pageQuery}`}>About</a>
+          </ListItem>
+          <ListItem>
+            <a href={`/rule${pageQuery}`}>Terms of Use</a>
+          </ListItem>
+          <ListItem>
+            <a href={`/privacy${pageQuery}`}>Privacy</a>
+          </ListItem>
+        </FlushList>
+      </FooterSection>
 
-      <section class="col mb-3">
-        <div>
-          Created by
-          <a
-            id="link-to-twitter"
-            href="https://twitter.com/Philomagi"
-            rel="external noopener noreferrer"
-            target="_blank"
-          >
-            Philomagi
-          </a>
-        </div>
-        <div>
-          Source on
-          <a
-            id="link-to-src"
-            href="https://github.com/tooppoo/ac6_assemble_tool/"
-            rel="external noopener noreferrer"
-            target="_blank"
-          >
-            Github
-          </a>
-        </div>
-        <div>
-          <a id="link-to-website" href="https://philomagi.dev" target="_blank">
-            https://philomagi.dev
-          </a>
-        </div>
-        <div>
-          v{appVersion}
-        </div>
-      </section>
+      <FooterSection caption="LINKS" class="col">
+        <FlushList>
+          <ListItem>
+            <a
+              id="link-to-twitter"
+              href="https://twitter.com/Philomagi"
+              rel="external noopener noreferrer"
+              target="_blank"
+            >
+              Twitter
+            </a>
+          </ListItem>
+          <ListItem>
+            <a
+              id="link-to-src"
+              href="https://github.com/tooppoo/ac6_assemble_tool/"
+              rel="external noopener noreferrer"
+              target="_blank"
+            >
+              Github
+            </a>
+          </ListItem>
+          <ListItem>
+            <a
+              id="link-to-website"
+              href="https://philomagi.dev"
+              target="_blank"
+            >
+              https://philomagi.dev
+            </a>
+          </ListItem>
+        </FlushList>
+      </FooterSection>
+    </div>
+    <div class="my-3">
+      v{appVersion}
     </div>
   </footer>
 </div>

--- a/packages/web/src/routes/parts-list/+page.svelte
+++ b/packages/web/src/routes/parts-list/+page.svelte
@@ -37,11 +37,12 @@
 
 <main class="parts-list-page py-4">
   <div class="container">
-    <h1 class="py-2 d-flex justify-content-center">
-      ARMORED CORE Ⅵ PARTS LIST
+    <h1 class="py-2 text-center">
+      ARMORED CORE Ⅵ<br class="d-block d-md-none" />
+      PARTS LIST
     </h1>
 
-    <h2 class="py-2 d-flex justify-content-center">
+    <h2 class="py-2 text-center">
       Regulation for {regulation.version}
     </h2>
 


### PR DESCRIPTION
## このPRの目的

フッターを含むレイアウトの可読性向上と依存更新自動デプロイフローの補強

## 主な変更点

- フッターをFooterSection/FlushList/ListItemで再構成し、リンクをセクションごとに整理してバージョン表記を明示
- parts-listページの見出しを中央寄せにし、モバイルで折り返すようにして可読性を向上
- 依存更新時の自動デプロイフローにGitHub Pages向け成果物のアップロードとデプロイジョブを追加し、is_dep_update出力を他ジョブと連携
- CollapseTextやIndex/PartsListViewの文言レイアウトを微調整

## レビュー観点

- フッター内リンクの遷移先・rel属性が従来通りか
- parts-listページのh1/h2配置と余白が意図するデザインに合っているか
- GitHub Pages追加ジョブがis_dep_update == trueの場合のみ実行され、Cloudflare Pagesデプロイと競合しないか

## 関連Issue / ADR

- Issue: なし
- ADR: なし

## チェックリスト

- [ ] 関連するIssueに紐づけた
- [ ] CIが成功している
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した