### PR TITLE
refactor: Resolve infinite reactivity loop and implement global language store

### DIFF
--- a/.changeset/bumpy-breads-admire.md
+++ b/.changeset/bumpy-breads-admire.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+refactor application state
+  

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ analyze.html
 # other
 .env
 tmp
+.devbox/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,9 @@ Managed by `/kiro:steering` command. Updates here reflect command changes.
   Pattern: File patterns for Conditional mode
 -->
 
+- `dependencies.md`: Always - パッケージ・モジュール依存関係の可視化と一方向依存の検証
+- `components.md`: Always - Svelteコンポーネント・モジュール依存関係の可視化とrune API活用ガイドライン
+
 ### Inclusion Modes
 
 - **Always**: Loaded in every interaction (default)

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
+  "packages": [
+    "nodejs@24.11.1",
+    "pnpm@10.24.0"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,138 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-12-05T15:03:55Z",
+      "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069?lastModified=1764947035"
+    },
+    "nodejs@24.11.1": {
+      "last_modified": "2025-12-05T15:03:55Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069#nodejs_24",
+      "source": "devbox-search",
+      "version": "24.11.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/h4ad12n85c04b2c5c1a4r8r5qr4i1afn-nodejs-24.11.1-libv8"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/akmrc34ry4wil7wq8ghxbh2dpvikschh-nodejs-24.11.1-dev"
+            }
+          ],
+          "store_path": "/nix/store/h57ln4r40qr349z1r8ri90n9i9xid3r5-nodejs-24.11.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r46dnkahacvrnavv5945aizq8b61kbwc-nodejs-24.11.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/7ihzshxrnl1xh935ff8va57aw1avwk5j-nodejs-24.11.1-libv8"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/82gbs5sgm1gpggsalpdlnxjkvr7bnkcc-nodejs-24.11.1-dev"
+            }
+          ],
+          "store_path": "/nix/store/r46dnkahacvrnavv5945aizq8b61kbwc-nodejs-24.11.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/68d27bbipwcv99inwbs6fb7vxbgd4q6j-nodejs-24.11.1",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/xj8y0v2v5ssdxbpz1bz9yivn109g3i4x-nodejs-24.11.1-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/136306lidz9kx8dlka3l2sf1q9i6ilc3-nodejs-24.11.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/68d27bbipwcv99inwbs6fb7vxbgd4q6j-nodejs-24.11.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lgggxsrdzisnbligi7irlh4qmqczs0xk-nodejs-24.11.1",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/qayyvn6vq1yx49lr30kkrpdl1jy99752-nodejs-24.11.1-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/i9s2w9xib1fbqrc2qmmyz17frhpvkmsk-nodejs-24.11.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/lgggxsrdzisnbligi7irlh4qmqczs0xk-nodejs-24.11.1"
+        }
+      }
+    },
+    "pnpm@10.24.0": {
+      "last_modified": "2025-11-28T17:56:46Z",
+      "resolved": "github:NixOS/nixpkgs/24e915b36ca87d32777d766da3a3f4e3ce22cc98#pnpm",
+      "source": "devbox-search",
+      "version": "10.24.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/09p3ygf7zdspqfyqn7z25k2q832hfklr-pnpm-10.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/09p3ygf7zdspqfyqn7z25k2q832hfklr-pnpm-10.24.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nkfhs7q2gk8nns4cr4r8gmvdi1dx99lg-pnpm-10.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nkfhs7q2gk8nns4cr4r8gmvdi1dx99lg-pnpm-10.24.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qwp6r0zxrm5h4qa55wym2k9dy84rsaiq-pnpm-10.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qwp6r0zxrm5h4qa55wym2k9dy84rsaiq-pnpm-10.24.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/x8brlvxzdkgpl75s9p7srnm2b5py8vnd-pnpm-10.24.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/x8brlvxzdkgpl75s9p7srnm2b5py8vnd-pnpm-10.24.0"
+        }
+      }
+    }
+  }
+}

--- a/docs/steering/components.md
+++ b/docs/steering/components.md
@@ -1,0 +1,655 @@
+# Components Architecture
+
+<!-- Inclusion Mode: Always -->
+
+_Last Updated: 2025-12-12_
+
+## 目的
+
+このドキュメントは、Svelteコンポーネントと、コンポーネントが直接依存しているモジュールとの依存関係を図示します。コンポーネント・モジュール間で一方向の依存関係になっていることを確認可能にします。
+
+## 核心原則
+
+### MUST要件
+
+- **Svelte 5 rune API**: 新規コンポーネントは Svelte 5 の rune API（`$state`, `$derived`, `$effect`）を用いて実装（AGENTS.md L24）
+- **プレゼンテーション層の責務最小化**: 主要な計算処理はプレーンなTypeScriptモジュールに集約し、コンポーネントは原則イベントハンドラのみを持つ（AGENTS.md L33）
+- **一方向依存**: コンポーネント→モジュールの依存のみ許可（逆方向禁止）
+
+### SHOULD要件
+
+- **レイヤー分離**: UI層（components/view）とロジック層（interaction/filter/sort）を物理的に分離
+- **コンポーネントの粒度**: 単一責任の原則に従い、小さく再利用可能なコンポーネントを作成
+
+## コンポーネント階層構造
+
+### 全体構成
+
+```txt
+packages/web/src/
+├── routes/                    # SvelteKitルーティング（ページコンポーネント）
+│   ├── +page.svelte              # トップページ
+│   ├── +layout.svelte            # 共通レイアウト
+│   ├── parts-list/+page.svelte   # パーツ一覧ページ
+│   └── about/*/+page.svelte      # Aboutページ（多言語）
+│
+├── lib/
+│   ├── components/            # 汎用UIコンポーネント（ドメイン非依存）
+│   │   ├── button/               # ボタン類
+│   │   ├── form/                 # フォーム要素
+│   │   ├── layout/               # レイアウト要素
+│   │   ├── modal/                # モーダル
+│   │   └── ...
+│   │
+│   ├── view/                  # ビュー固有コンポーネント（ドメイン依存）
+│   │   ├── index/                # トップページビュー
+│   │   │   ├── Index.svelte         # メインコンポーネント
+│   │   │   ├── form/                # パーツ選択フォーム
+│   │   │   ├── random/              # ランダム生成UI
+│   │   │   ├── report/              # レポート表示
+│   │   │   └── share/               # 共有機能UI
+│   │   │
+│   │   └── parts-list/           # パーツ一覧ビュー
+│   │       ├── PartsListView.svelte # メインコンポーネント
+│   │       ├── filter/              # フィルターUI
+│   │       ├── sort/                # ソートUI
+│   │       └── slot/                # スロット選択UI
+│   │
+│   └── (ロジックモジュール)
+│       ├── interaction/          # ユーザー操作処理
+│       ├── filter/               # フィルターロジック
+│       └── sort/                 # ソートロジック
+```
+
+## コンポーネント依存関係図
+
+### ページレベル依存
+
+```mermaid
+---
+config:
+  theme: default
+  themeVariables:
+    fontSize: 14px
+---
+graph TD
+    %% Pages
+    IndexPage["+page.svelte<br/>(トップページ)"]
+    PartsListPage["+page.svelte<br/>(パーツ一覧)"]
+    Layout["+layout.svelte<br/>(共通レイアウト)"]
+
+    %% View Components
+    IndexView["Index.svelte<br/>(メインビュー)"]
+    PartsListView["PartsListView.svelte<br/>(一覧ビュー)"]
+
+    %% Layout Components
+    Navbar["Navbar.svelte"]
+    ErrorModal["ErrorModal.svelte"]
+
+    %% Dependencies
+    IndexPage --> IndexView
+    PartsListPage --> PartsListView
+    Layout --> Navbar
+    Layout --> ErrorModal
+
+    %% Core Modules
+    CoreAssembly["@ac6_assemble_tool/core<br/>assembly/*"]
+    PartsCandidates["@ac6_assemble_tool/parts<br/>types/candidates"]
+    SharedLogger["@ac6_assemble_tool/shared<br/>logger"]
+
+    IndexView -.-> CoreAssembly
+    IndexView -.-> PartsCandidates
+    IndexView -.-> SharedLogger
+    PartsListView -.-> PartsCandidates
+    PartsListView -.-> SharedLogger
+
+    style IndexPage fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
+    style PartsListPage fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
+    style Layout fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
+    style IndexView fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    style PartsListView fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    style Navbar fill:#e1f5ff,stroke:#0288d1,stroke-width:2px
+    style ErrorModal fill:#e1f5ff,stroke:#0288d1,stroke-width:2px
+    style CoreAssembly fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style PartsCandidates fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style SharedLogger fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+```
+
+### Index ビュー詳細依存
+
+```mermaid
+---
+config:
+  theme: default
+  themeVariables:
+    fontSize: 12px
+---
+graph TD
+    %% Main Component
+    IndexView["Index.svelte"]
+
+    %% UI Components (components/)
+    TextButton["TextButton"]
+    LanguageForm["LanguageForm"]
+    CollapseText["CollapseText"]
+    NavButton["NavButton"]
+    Navbar["Navbar"]
+    ToolSection["ToolSection"]
+    ErrorModal["ErrorModal"]
+
+    %% View-specific Components (view/index/)
+    PartsSelectForm["PartsSelectForm"]
+    RandomUI["RandomAssemblyOffCanvas"]
+    ReportUI["ReportListViewer"]
+    ShareUI["ShareAssembly"]
+    StoreUI["StoreAssembly"]
+    StatusBadge["StatusBadgeList"]
+
+    %% Modules (TypeScript)
+    InteractionModule["interaction/<br/>bootstrap.ts<br/>assembly.ts<br/>share.ts"]
+    CoreModule["@ac6_assemble_tool/core<br/>assembly/*"]
+    PartsModule["@ac6_assemble_tool/parts"]
+    SharedModule["@ac6_assemble_tool/shared"]
+
+    %% Dependencies
+    IndexView --> TextButton
+    IndexView --> LanguageForm
+    IndexView --> CollapseText
+    IndexView --> NavButton
+    IndexView --> Navbar
+    IndexView --> ToolSection
+    IndexView --> ErrorModal
+    IndexView --> PartsSelectForm
+    IndexView --> RandomUI
+    IndexView --> ReportUI
+    IndexView --> ShareUI
+    IndexView --> StoreUI
+    IndexView --> StatusBadge
+
+    IndexView -.->|ロジック呼び出し| InteractionModule
+    IndexView -.->|直接依存| CoreModule
+    IndexView -.->|直接依存| PartsModule
+    IndexView -.->|直接依存| SharedModule
+
+    InteractionModule -.-> CoreModule
+    InteractionModule -.-> PartsModule
+
+    style IndexView fill:#fff3e0,stroke:#f57c00,stroke-width:3px
+    style TextButton fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style LanguageForm fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style CollapseText fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style NavButton fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style Navbar fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style ToolSection fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style ErrorModal fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style PartsSelectForm fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style RandomUI fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style ReportUI fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style ShareUI fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style StoreUI fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style StatusBadge fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style InteractionModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style CoreModule fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    style PartsModule fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    style SharedModule fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+```
+
+### PartsListView 詳細依存
+
+```mermaid
+---
+config:
+  theme: default
+  themeVariables:
+    fontSize: 12px
+---
+graph TD
+    %% Main Component
+    PartsListView["PartsListView.svelte"]
+
+    %% UI Components (components/)
+    CollapseText["CollapseText"]
+
+    %% View-specific Components
+    FilterPanel["FilterPanel"]
+    PartsGrid["PartsGrid"]
+    SlotSelector["SlotSelector"]
+    SortControl["SortControl"]
+    EmptyState["EmptyState"]
+
+    %% Modules (TypeScript)
+    FilterModule["filter/<br/>filters-core.ts<br/>serialization.ts"]
+    SortModule["sort/<br/>sort.ts"]
+    SlotModule["slot/<br/>slot-utils.ts"]
+    StateModule["state/<br/>state-serializer.ts<br/>view-mode.ts"]
+    StoreModule["stores/<br/>favorite-store.ts"]
+
+    %% Core Modules
+    PartsModule["@ac6_assemble_tool/parts<br/>attributes-utils<br/>types/*"]
+    SharedModule["@ac6_assemble_tool/shared<br/>logger"]
+
+    %% Dependencies
+    PartsListView --> CollapseText
+    PartsListView --> FilterPanel
+    PartsListView --> PartsGrid
+    PartsListView --> SlotSelector
+    PartsListView --> SortControl
+    PartsListView --> EmptyState
+
+    PartsListView -.->|ロジック呼び出し| FilterModule
+    PartsListView -.->|ロジック呼び出し| SortModule
+    PartsListView -.->|ロジック呼び出し| SlotModule
+    PartsListView -.->|ロジック呼び出し| StateModule
+    PartsListView -.->|Store購読| StoreModule
+
+    PartsListView -.->|直接依存| PartsModule
+    PartsListView -.->|直接依存| SharedModule
+
+    FilterModule -.-> PartsModule
+    SortModule -.-> PartsModule
+    StoreModule -.-> SharedModule
+
+    style PartsListView fill:#fff3e0,stroke:#f57c00,stroke-width:3px
+    style CollapseText fill:#e1f5ff,stroke:#0288d1,stroke-width:1px
+    style FilterPanel fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style PartsGrid fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style SlotSelector fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style SortControl fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style EmptyState fill:#ffe0b2,stroke:#ff6f00,stroke-width:1px
+    style FilterModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style SortModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style SlotModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style StateModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style StoreModule fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style PartsModule fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    style SharedModule fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+```
+
+## コンポーネントカテゴリ
+
+### 1. ページコンポーネント（routes/）
+
+**責務**: SvelteKitルーティングのエントリポイント
+
+**特徴**:
+- `+page.svelte`: ページ本体
+- `+layout.svelte`: 共通レイアウト
+- `+page.ts` / `+page.server.ts`: データロード
+
+**依存ルール**:
+- View コンポーネントを組み込む
+- データロードロジックは `+page.ts` に集約
+- 直接的なビジネスロジックは持たない
+
+**例**:
+```svelte
+<!-- routes/+page.svelte -->
+<script lang="ts">
+  import Index from '$lib/view/index/Index.svelte'
+  import type { PageData } from './+page'
+
+  interface Props {
+    data: PageData
+  }
+  let { data }: Props = $props()
+</script>
+
+<Index regulation={data.regulation} partsPool={data.partsPool} />
+```
+
+### 2. 汎用UIコンポーネント（components/）
+
+**責務**: ドメイン非依存の再利用可能UIパーツ
+
+**配置**: `src/lib/components/`
+
+**特徴**:
+- ビジネスロジックを持たない
+- `@ac6_assemble_tool/core` や `@ac6_assemble_tool/parts` への依存禁止
+- propsでデータを受け取り、イベントで通知
+
+**サブディレクトリ**:
+- `button/`: ボタン類（IconButton, TextButton）
+- `form/`: フォーム要素（Switch）
+- `layout/`: レイアウト要素（Navbar, CollapseText, ToolSection）
+- `modal/`: モーダル（ErrorModal）
+- `list/`: リスト表示（FlushList, ListItem）
+- `spacing/`: スペーシング（Margin）
+- `tooltip/`: ツールチップ（ClickToggleTooltip）
+
+**例**:
+```svelte
+<!-- components/button/TextButton.svelte -->
+<script lang="ts">
+  interface Props {
+    text: string
+    onClick?: () => void
+    disabled?: boolean
+  }
+  let { text, onClick, disabled = false }: Props = $props()
+</script>
+
+<button on:click={onClick} disabled={disabled}>
+  {text}
+</button>
+```
+
+### 3. ビュー固有コンポーネント（view/）
+
+**責務**: 特定の画面・機能に特化したUIコンポーネント
+
+**配置**: `src/lib/view/`
+
+**特徴**:
+- ドメインロジックを呼び出す
+- `@ac6_assemble_tool/core`, `@ac6_assemble_tool/parts` への依存可能
+- Svelte 5 rune API（`$state`, `$derived`, `$effect`）を活用
+
+**サブディレクトリ**:
+- `index/`: トップページビュー（機体組み立て）
+  - `Index.svelte`: メインコンポーネント
+  - `form/`: パーツ選択フォーム
+  - `random/`: ランダム生成UI
+  - `report/`: レポート表示
+  - `share/`: 共有機能UI
+  - `store/`: 保存・読み込みUI
+
+- `parts-list/`: パーツ一覧ビュー
+  - `PartsListView.svelte`: メインコンポーネント
+  - `filter/`: フィルターUI
+  - `sort/`: ソートUI
+  - `slot/`: スロット選択UI
+  - `state/`: 状態管理UI
+
+**例**:
+```svelte
+<!-- view/parts-list/PartsListView.svelte -->
+<script lang="ts">
+  import { applyFilters } from './filter/filters-core'
+  import { sortPartsByKey } from './sort/sort'
+  import type { ACParts } from '@ac6_assemble_tool/parts/types/base/types'
+
+  interface Props {
+    parts: ACParts[]
+    regulation: Regulation
+  }
+  let { parts, regulation }: Props = $props()
+
+  // ロジックモジュールを呼び出して計算
+  let filteredParts = $derived(applyFilters(parts, filters))
+  let sortedParts = $derived(sortPartsByKey(filteredParts, sortKey))
+</script>
+```
+
+### 4. ロジックモジュール（.ts ファイル）
+
+**責務**: ビジネスロジック・計算処理
+
+**配置**: `src/lib/view/*/interaction/`, `filter/`, `sort/` 等
+
+**特徴**:
+- プレーンなTypeScript関数/クラス
+- コンポーネントから呼び出される（逆方向依存禁止）
+- テスタブルな純粋関数を優先
+
+**例**:
+```typescript
+// view/parts-list/filter/filters-core.ts
+import type { ACParts } from '@ac6_assemble_tool/parts/types/base/types'
+
+export function applyFilters(
+  parts: ACParts[],
+  filters: FiltersPerSlot
+): ACParts[] {
+  return parts.filter(part => {
+    // フィルター適用ロジック
+    return matchesFilter(part, filters)
+  })
+}
+```
+
+## 依存関係の検証手順
+
+### 新規コンポーネント作成時
+
+1. **カテゴリ判断**: コンポーネントがどのカテゴリに属するか決定
+   - ドメイン非依存 → `components/`
+   - ビュー固有 → `view/*/`
+   - ページ → `routes/*/`
+
+2. **依存方向確認**:
+   ```txt
+   OK: Component → TypeScript Module → Core/Parts/Shared
+   NG: TypeScript Module → Component (逆方向依存)
+   NG: components/ → @ac6_assemble_tool/core (ドメイン依存)
+   ```
+
+3. **Svelte 5 rune 使用確認**:
+   - `let foo = $state(...)`: リアクティブな状態
+   - `let bar = $derived(...)`: 派生状態
+   - `$effect(() => {...})`: 副作用
+
+4. **責務最小化確認**:
+   - 計算ロジックは別モジュールに分離されているか？
+   - コンポーネントはUIとイベントハンドラのみか？
+
+### コンポーネント間依存の追加時
+
+1. **親子関係の確認**:
+   - 親コンポーネントが子コンポーネントをimport（正常）
+   - 子から親をimport（循環依存リスク、避ける）
+
+2. **イベント伝播**:
+   - 子→親への通知はイベント経由
+   - 親→子へのデータはprops経由
+
+3. **共通コンポーネントの抽出**:
+   - 複数の親から使われる → `components/` へ移動
+   - 特定ビューでのみ使用 → `view/*/` 内に配置
+
+## Svelte 5 Rune API ガイドライン
+
+### $state - リアクティブな状態
+
+```svelte
+<script lang="ts">
+  // プリミティブ
+  let count = $state(0)
+
+  // オブジェクト
+  let user = $state({ name: 'Alice', age: 30 })
+
+  // 配列
+  let items = $state<string[]>([])
+</script>
+
+<button onclick={() => count++}>
+  Count: {count}
+</button>
+```
+
+### $derived - 派生状態
+
+```svelte
+<script lang="ts">
+  let count = $state(0)
+
+  // シンプルな派生
+  let doubled = $derived(count * 2)
+
+  // 複雑な派生（$derived.by を使用）
+  let filtered = $derived.by(() => {
+    return items.filter(item => item.active)
+  })
+</script>
+
+<p>Doubled: {doubled}</p>
+```
+
+### $effect - 副作用
+
+```svelte
+<script lang="ts">
+  let count = $state(0)
+
+  // 副作用（ログ、ストレージ保存等）
+  $effect(() => {
+    console.log('Count changed:', count)
+    localStorage.setItem('count', String(count))
+  })
+</script>
+```
+
+### $props - プロパティ
+
+```svelte
+<script lang="ts">
+  interface Props {
+    title: string
+    count?: number
+  }
+
+  // デフォルト値付き
+  let { title, count = 0 }: Props = $props()
+</script>
+
+<h1>{title}</h1>
+<p>Count: {count}</p>
+```
+
+## URL クエリパラメータの取得
+
+**SHOULD原則**: クライアントでクエリパラメータを参照する際は `$app/state` の `page.url.search` を `withPageQuery` と `$derived.by` で監視し、`window.location.search` へ直接依存しないこと（AGENTS.md L175）
+
+**理由**: SSR/CSRの一貫性確保
+
+**実装例**:
+```typescript
+// utils/page-query.ts
+import { page } from '$app/state'
+
+export function withPageQuery<T>(fn: (search: string) => T): () => T {
+  return () => fn(page.url.search)
+}
+```
+
+```svelte
+<!-- Component.svelte -->
+<script lang="ts">
+  import { withPageQuery } from '$lib/utils/page-query'
+  import { parseQueryParams } from './query-parser'
+
+  // SSR/CSR両対応のクエリ監視
+  let queryParams = $derived.by(
+    withPageQuery(search => parseQueryParams(search))
+  )
+</script>
+```
+
+## アンチパターン
+
+### ❌ コンポーネント内での重いロジック
+
+```svelte
+<!-- BAD: コンポーネント内で計算 -->
+<script lang="ts">
+  let parts = $state<ACParts[]>([])
+
+  let filtered = $derived.by(() => {
+    // 複雑なフィルタリング処理を直接書く（テスト困難）
+    return parts.filter(p => {
+      // 100行のロジック...
+    })
+  })
+</script>
+```
+
+### ✅ ロジックを分離
+
+```typescript
+// filter/filters-core.ts (別モジュール)
+export function applyFilters(parts: ACParts[], filters: Filters): ACParts[] {
+  // テスト可能な純粋関数
+  return parts.filter(p => matchesFilter(p, filters))
+}
+```
+
+```svelte
+<!-- GOOD: モジュールを呼び出すだけ -->
+<script lang="ts">
+  import { applyFilters } from './filter/filters-core'
+
+  let parts = $state<ACParts[]>([])
+  let filters = $state<Filters>({})
+
+  let filtered = $derived(applyFilters(parts, filters))
+</script>
+```
+
+### ❌ 逆方向依存
+
+```typescript
+// BAD: ロジックモジュールからコンポーネントをimport
+import SomeComponent from './SomeComponent.svelte'
+
+export function doSomething() {
+  // コンポーネントを使おうとする（禁止）
+}
+```
+
+### ✅ 一方向依存
+
+```typescript
+// GOOD: ロジックモジュールは純粋関数のみ
+export function doSomething(data: Data): Result {
+  // ビジネスロジック
+  return result
+}
+```
+
+```svelte
+<!-- コンポーネントからロジックを呼び出す -->
+<script lang="ts">
+  import { doSomething } from './logic'
+
+  let result = $derived(doSomething(data))
+</script>
+```
+
+## トラブルシューティング
+
+### 循環依存が発生した場合
+
+1. **依存グラフの確認**:
+   ```bash
+   npx madge --circular --extensions ts,svelte packages/web/src
+   ```
+
+2. **共通コンポーネントの抽出**: 循環の原因となるコンポーネントを上位に移動
+
+3. **イベント駆動の採用**: 子→親の通知をイベント経由に変更
+
+### パフォーマンス問題
+
+1. **$derived の最適化**: 不要な再計算を避ける
+2. **コンポーネント分割**: 大きなコンポーネントを小さく分割し、再レンダリング範囲を最小化
+3. **メモ化**: 重い計算は事前に実行し、結果をキャッシュ
+
+## 参考資料
+
+### 関連ドキュメント
+
+- [AGENTS.md L24](AGENTS.md): Svelte 5 rune API の活用（MUST）
+- [AGENTS.md L33](AGENTS.md): プレゼンテーション層の責務最小化（SHOULD）
+- [AGENTS.md L175](AGENTS.md): URL クエリ取得の方針（SHOULD）
+- [docs/steering/structure.md](docs/steering/structure.md): プロジェクト構造とレイヤーアーキテクチャ
+- [docs/steering/dependencies.md](docs/steering/dependencies.md): パッケージ間依存関係
+
+### 外部リソース
+
+- [Svelte 5 Documentation](https://svelte.dev/docs/svelte/overview)
+- [SvelteKit Documentation](https://kit.svelte.dev/docs)
+
+## 変更履歴
+
+- **2025-12-12**: 初版作成 - コンポーネント階層、依存関係図、Svelte 5 rune ガイドラインを記載

--- a/docs/steering/components.md
+++ b/docs/steering/components.md
@@ -272,16 +272,19 @@ graph TD
 **責務**: SvelteKitルーティングのエントリポイント
 
 **特徴**:
+
 - `+page.svelte`: ページ本体
 - `+layout.svelte`: 共通レイアウト
 - `+page.ts` / `+page.server.ts`: データロード
 
 **依存ルール**:
+
 - View コンポーネントを組み込む
 - データロードロジックは `+page.ts` に集約
 - 直接的なビジネスロジックは持たない
 
 **例**:
+
 ```svelte
 <!-- routes/+page.svelte -->
 <script lang="ts">
@@ -304,11 +307,13 @@ graph TD
 **配置**: `src/lib/components/`
 
 **特徴**:
+
 - ビジネスロジックを持たない
 - `@ac6_assemble_tool/core` や `@ac6_assemble_tool/parts` への依存禁止
 - propsでデータを受け取り、イベントで通知
 
 **サブディレクトリ**:
+
 - `button/`: ボタン類（IconButton, TextButton）
 - `form/`: フォーム要素（Switch）
 - `layout/`: レイアウト要素（Navbar, CollapseText, ToolSection）
@@ -318,6 +323,7 @@ graph TD
 - `tooltip/`: ツールチップ（ClickToggleTooltip）
 
 **例**:
+
 ```svelte
 <!-- components/button/TextButton.svelte -->
 <script lang="ts">
@@ -341,11 +347,13 @@ graph TD
 **配置**: `src/lib/view/`
 
 **特徴**:
+
 - ドメインロジックを呼び出す
 - `@ac6_assemble_tool/core`, `@ac6_assemble_tool/parts` への依存可能
 - Svelte 5 rune API（`$state`, `$derived`, `$effect`）を活用
 
 **サブディレクトリ**:
+
 - `index/`: トップページビュー（機体組み立て）
   - `Index.svelte`: メインコンポーネント
   - `form/`: パーツ選択フォーム
@@ -362,6 +370,7 @@ graph TD
   - `state/`: 状態管理UI
 
 **例**:
+
 ```svelte
 <!-- view/parts-list/PartsListView.svelte -->
 <script lang="ts">
@@ -388,11 +397,13 @@ graph TD
 **配置**: `src/lib/view/*/interaction/`, `filter/`, `sort/` 等
 
 **特徴**:
+
 - プレーンなTypeScript関数/クラス
 - コンポーネントから呼び出される（逆方向依存禁止）
 - テスタブルな純粋関数を優先
 
 **例**:
+
 ```typescript
 // view/parts-list/filter/filters-core.ts
 import type { ACParts } from '@ac6_assemble_tool/parts/types/base/types'
@@ -418,6 +429,7 @@ export function applyFilters(
    - ページ → `routes/*/`
 
 2. **依存方向確認**:
+
    ```txt
    OK: Component → TypeScript Module → Core/Parts/Shared
    NG: TypeScript Module → Component (逆方向依存)
@@ -524,6 +536,7 @@ export function applyFilters(
 **理由**: SSR/CSRの一貫性確保
 
 **実装例**:
+
 ```typescript
 // utils/page-query.ts
 import { page } from '$app/state'
@@ -621,6 +634,7 @@ export function doSomething(data: Data): Result {
 ### 循環依存が発生した場合
 
 1. **依存グラフの確認**:
+
    ```bash
    npx madge --circular --extensions ts,svelte packages/web/src
    ```

--- a/docs/steering/components.md
+++ b/docs/steering/components.md
@@ -1,8 +1,7 @@
 # Components Architecture
 
 <!-- Inclusion Mode: Always -->
-
-_Last Updated: 2025-12-12_
+<!-- Last Updated: 2025-12-12 -->
 
 ## 目的
 

--- a/docs/steering/dependencies.md
+++ b/docs/steering/dependencies.md
@@ -97,14 +97,17 @@ graph TD
 **責務**: 技術的インフラレイヤー
 
 **提供機能**:
+
 - 構造化ログ（logger）
 - 共通ユーティリティ（array, number等）
 
 **依存先**:
+
 - 外部パッケージ: `@praha/byethrow`
 - 内部パッケージ: なし（最下位レイヤー）
 
 **被依存元**:
+
 - `@ac6_assemble_tool/core`
 - `@ac6_assemble_tool/parts`
 - `@ac6_assemble_tool/web`
@@ -116,15 +119,18 @@ graph TD
 **責務**: ドメインデータ層 - パーツ定義とバージョン管理
 
 **提供機能**:
+
 - パーツ型定義（フレーム系、武装系、内装系、拡張系）
 - パッチバージョン対応
 - パーツ実体定義
 - パーツ属性ユーティリティ
 
 **依存先**:
+
 - `@ac6_assemble_tool/shared`
 
 **被依存元**:
+
 - `@ac6_assemble_tool/core`
 - `@ac6_assemble_tool/web`
 
@@ -135,6 +141,7 @@ graph TD
 **責務**: ビジネスロジック・計算エンジン
 
 **提供機能**:
+
 - 機体組み立てロジック
 - パーツフィルタリング
 - ランダム生成・検証
@@ -142,11 +149,13 @@ graph TD
 - データ永続化（IndexedDB）
 
 **依存先**:
+
 - `@ac6_assemble_tool/parts`
 - `@ac6_assemble_tool/shared`
 - 外部パッケージ: `valibot`, `ulid`, `@praha/byethrow`, `@philomagi/base-error.js`
 
 **被依存元**:
+
 - `@ac6_assemble_tool/web`
 
 **特記事項**: UIに依存しない純粋なビジネスロジック層として設計
@@ -156,12 +165,14 @@ graph TD
 **責務**: UI層 - Web フロントエンド
 
 **提供機能**:
+
 - SvelteKit ベースの Web アプリケーション
 - ビュー固有ロジック（フィルター、インタラクション、レポート）
 - 国際化対応（i18n）
 - パッチバージョン別データ管理
 
 **依存先**:
+
 - `@ac6_assemble_tool/core`
 - `@ac6_assemble_tool/parts`
 - `@ac6_assemble_tool/shared`
@@ -208,6 +219,7 @@ graph TD
    - 技術的ユーティリティ → `shared`
 
 2. **依存方向確認**: 依存グラフに従い、上位→下位のみ許可されていることを確認
+
    ```txt
    OK: web → core → parts → shared
    NG: parts → core (下位から上位への依存)
@@ -215,6 +227,7 @@ graph TD
    ```
 
 3. **循環依存チェック**: 追加する依存が循環を生じないか確認
+
    ```bash
    # 依存グラフの可視化（例: madge を使用）
    pnpm add -D madge
@@ -230,6 +243,7 @@ graph TD
 2. **依存方向の確認**: 上位→下位の一方向依存となるか検証
 
 3. **package.json への追加**:
+
    ```json
    {
      "dependencies": {
@@ -239,6 +253,7 @@ graph TD
    ```
 
 4. **動作確認**:
+
    ```bash
    pnpm install
    pnpm run build
@@ -268,6 +283,7 @@ graph TD
 ### 循環依存が発生した場合
 
 1. **依存グラフの確認**:
+
    ```bash
    npx madge --circular --extensions ts packages/
    ```
@@ -279,6 +295,7 @@ graph TD
 ### ビルドエラー "Cannot find module" が発生
 
 1. **workspace インストール**:
+
    ```bash
    pnpm install
    ```

--- a/docs/steering/dependencies.md
+++ b/docs/steering/dependencies.md
@@ -1,0 +1,305 @@
+# Dependencies Management
+
+<!-- Inclusion Mode: Always -->
+
+_Last Updated: 2025-12-12_
+
+## 目的
+
+このドキュメントは、プロジェクトの依存関係を可視化し、一方向依存の原則が維持されていることを確認可能にします。仕様の追加・変更時に、このドキュメントを参照して依存関係の整合性を検証してください。
+
+## 核心原則
+
+### MUST要件
+
+- **依存の一方向性**: 依存は常に一方向とすること。相互依存は禁止（AGENTS.md L170）
+- **循環依存の禁止**: パッケージ間、モジュール間、レイヤー間のいずれでも循環依存を発生させない
+- **抽象への依存**: 具象モジュールよりも抽象モジュールへの依存を優先（AGENTS.md L325）
+
+### SHOULD要件
+
+- **安定依存の原則**: より安定したモジュールに依存させる（より多くのモジュールに依存されているモジュール）（AGENTS.md L324）
+- **レイヤー分離**: 異なるレイヤーのコードは物理的に別ディレクトリに配置（AGENTS.md L181）
+- **上位→下位依存**: 依存は高次→低次の一方向（上位が下位へ）（AGENTS.md L182）
+
+## パッケージ依存関係図
+
+### 全体構成
+
+```mermaid
+---
+config:
+  theme: default
+  themeVariables:
+    fontSize: 16px
+---
+graph TD
+    shared[shared<br/>技術的インフラ]
+    parts[parts<br/>パーツデータ]
+    core[core<br/>ビジネスロジック]
+    web[web<br/>UI/フロントエンド]
+
+    spec[spec<br/>テスト仕様]
+    tsconfig[tsconfig<br/>共通TS設定]
+    eslint[eslint<br/>共通Lint設定]
+
+    core --> shared
+    core --> parts
+    parts --> shared
+    web --> core
+    web --> parts
+    web --> shared
+
+    style shared fill:#e1f5ff,stroke:#0288d1,stroke-width:2px
+    style parts fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    style core fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style web fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
+    style spec fill:#fce4ec,stroke:#c2185b,stroke-width:1px,stroke-dasharray: 5 5
+    style tsconfig fill:#fce4ec,stroke:#c2185b,stroke-width:1px,stroke-dasharray: 5 5
+    style eslint fill:#fce4ec,stroke:#c2185b,stroke-width:1px,stroke-dasharray: 5 5
+```
+
+### レイヤー構造
+
+```txt
+┌─────────────────────────────────────────┐
+│  web (UI層)                             │  ← 最上位レイヤー
+│  - ビュー固有ロジック                    │
+│  - SvelteKit ルーティング                │
+│  - ユーザー操作                         │
+└─────────────────────────────────────────┘
+              ↓ 依存
+┌─────────────────────────────────────────┐
+│  core (アプリケーション/ドメイン層)       │
+│  - AC6アセンブリ計算エンジン             │
+│  - ビジネスロジック                     │
+│  - データ永続化                         │
+└─────────────────────────────────────────┘
+              ↓ 依存
+┌─────────────────────────────────────────┐
+│  parts (ドメインデータ層)                │
+│  - パーツ型定義                         │
+│  - パッチバージョン対応                  │
+│  - パーツ実体定義                       │
+└─────────────────────────────────────────┘
+              ↓ 依存
+┌─────────────────────────────────────────┐
+│  shared (インフラストラクチャ層)         │  ← 最下位レイヤー
+│  - logger                               │
+│  - 共通ユーティリティ                   │
+└─────────────────────────────────────────┘
+```
+
+## パッケージ詳細
+
+### @ac6_assemble_tool/shared
+
+**責務**: 技術的インフラレイヤー
+
+**提供機能**:
+- 構造化ログ（logger）
+- 共通ユーティリティ（array, number等）
+
+**依存先**:
+- 外部パッケージ: `@praha/byethrow`
+- 内部パッケージ: なし（最下位レイヤー）
+
+**被依存元**:
+- `@ac6_assemble_tool/core`
+- `@ac6_assemble_tool/parts`
+- `@ac6_assemble_tool/web`
+
+**設計決定**: [ADR 20251018](docs/adr/20251018-logger-placement-in-shared-package.md) - logger を shared に配置し、循環依存リスクをゼロに
+
+### @ac6_assemble_tool/parts
+
+**責務**: ドメインデータ層 - パーツ定義とバージョン管理
+
+**提供機能**:
+- パーツ型定義（フレーム系、武装系、内装系、拡張系）
+- パッチバージョン対応
+- パーツ実体定義
+- パーツ属性ユーティリティ
+
+**依存先**:
+- `@ac6_assemble_tool/shared`
+
+**被依存元**:
+- `@ac6_assemble_tool/core`
+- `@ac6_assemble_tool/web`
+
+**特記事項**: ビジネスロジックを持たず、純粋なデータ定義のみを担当
+
+### @ac6_assemble_tool/core
+
+**責務**: ビジネスロジック・計算エンジン
+
+**提供機能**:
+- 機体組み立てロジック
+- パーツフィルタリング
+- ランダム生成・検証
+- データシリアライズ（URL/クエリパラメータ）
+- データ永続化（IndexedDB）
+
+**依存先**:
+- `@ac6_assemble_tool/parts`
+- `@ac6_assemble_tool/shared`
+- 外部パッケージ: `valibot`, `ulid`, `@praha/byethrow`, `@philomagi/base-error.js`
+
+**被依存元**:
+- `@ac6_assemble_tool/web`
+
+**特記事項**: UIに依存しない純粋なビジネスロジック層として設計
+
+### @ac6_assemble_tool/web
+
+**責務**: UI層 - Web フロントエンド
+
+**提供機能**:
+- SvelteKit ベースの Web アプリケーション
+- ビュー固有ロジック（フィルター、インタラクション、レポート）
+- 国際化対応（i18n）
+- パッチバージョン別データ管理
+
+**依存先**:
+- `@ac6_assemble_tool/core`
+- `@ac6_assemble_tool/parts`
+- `@ac6_assemble_tool/shared`
+- 外部パッケージ: `svelte`, `@sveltejs/kit`, `dexie`, `i18next`, `bootstrap` 等
+
+**被依存元**: なし（最上位レイヤー）
+
+**特記事項**: プレゼンテーション層の責務を最小化し、主要な計算処理は core に委譲
+
+## サポートパッケージ
+
+### @ac6_assemble_tool/spec
+
+**責務**: テスト仕様・共通テストライブラリ
+
+**依存形態**: devDependencies（実行時依存なし）
+
+**使用パッケージ**: `core`, `parts`, `shared`, `web`
+
+### @ac6_assemble_tool/tsconfig
+
+**責務**: 共通 TypeScript 設定
+
+**依存形態**: devDependencies
+
+**使用パッケージ**: 全パッケージ
+
+### @ac6_assemble_tool/eslint
+
+**責務**: 共通 ESLint 設定
+
+**依存形態**: devDependencies
+
+**使用パッケージ**: 全パッケージ
+
+## 依存関係の検証手順
+
+### 新機能追加時
+
+1. **レイヤー確認**: 追加する機能がどのレイヤーに属するか判断
+   - UI操作 → `web`
+   - ビジネスロジック → `core`
+   - データ定義 → `parts`
+   - 技術的ユーティリティ → `shared`
+
+2. **依存方向確認**: 依存グラフに従い、上位→下位のみ許可されていることを確認
+   ```txt
+   OK: web → core → parts → shared
+   NG: parts → core (下位から上位への依存)
+   NG: core → web (下位から上位への依存)
+   ```
+
+3. **循環依存チェック**: 追加する依存が循環を生じないか確認
+   ```bash
+   # 依存グラフの可視化（例: madge を使用）
+   pnpm add -D madge
+   npx madge --circular --extensions ts packages/
+   ```
+
+### パッケージ間依存の追加手順
+
+1. **必要性の確認**: 本当にパッケージ間依存が必要か検討
+   - 重複コードの削除が目的 → 共通化を検討
+   - 機能の再利用 → レイヤー構造に適合するか確認
+
+2. **依存方向の確認**: 上位→下位の一方向依存となるか検証
+
+3. **package.json への追加**:
+   ```json
+   {
+     "dependencies": {
+       "@ac6_assemble_tool/shared": "workspace:*"
+     }
+   }
+   ```
+
+4. **動作確認**:
+   ```bash
+   pnpm install
+   pnpm run build
+   pnpm run test
+   ```
+
+## 外部依存の管理
+
+### 依存追加の原則
+
+- **承認手順必須**: 新しい依存を追加する際は `docs/checklist/add-dependency.md` を参照し、承認を得る（AGENTS.md L91）
+- **バージョン固定**: セキュリティ重視で具体的なバージョンを指定（キャレット・チルダ不使用）（AGENTS.md L362）
+- **定期更新**: Renovate による自動更新PR
+
+### 共通外部依存
+
+以下のパッケージは複数のパッケージで使用されています：
+
+- **@praha/byethrow**: Result型実装（[ADR 20251020](docs/adr/20251020-adopt-byethrow-for-result-type.md)）
+  - 使用: `shared`, `core`, `web`
+
+- **ulid**: ユニークID生成
+  - 使用: `core`, `web`
+
+## トラブルシューティング
+
+### 循環依存が発生した場合
+
+1. **依存グラフの確認**:
+   ```bash
+   npx madge --circular --extensions ts packages/
+   ```
+
+2. **共通コードの抽出**: 循環の原因となるコードを下位レイヤー（`shared`）へ移動
+
+3. **インターフェース分離**: 抽象に依存するよう設計を変更
+
+### ビルドエラー "Cannot find module" が発生
+
+1. **workspace インストール**:
+   ```bash
+   pnpm install
+   ```
+
+2. **依存関係の確認**: `package.json` の `dependencies` に適切に記載されているか確認
+
+3. **TypeScript 設定**: `tsconfig.json` の `references` が正しいか確認
+
+## 参考資料
+
+### 関連ドキュメント
+
+- [AGENTS.md L161-L183](AGENTS.md): レイヤリングと配置、依存の一方向性
+- [docs/steering/structure.md](docs/steering/structure.md): プロジェクト構造とレイヤーアーキテクチャ
+- [docs/checklist/add-dependency.md](docs/checklist/add-dependency.md): 依存追加時のチェックリスト
+
+### ADR（Architecture Decision Records）
+
+- [ADR 20251018](docs/adr/20251018-logger-placement-in-shared-package.md): logger を shared パッケージに配置
+- [ADR 20251020](docs/adr/20251020-adopt-byethrow-for-result-type.md): Result型として byethrow を採用
+
+## 変更履歴
+
+- **2025-12-12**: 初版作成 - パッケージ依存関係図、検証手順、トラブルシューティングを記載

--- a/docs/steering/dependencies.md
+++ b/docs/steering/dependencies.md
@@ -1,8 +1,7 @@
 # Dependencies Management
 
 <!-- Inclusion Mode: Always -->
-
-_Last Updated: 2025-12-12_
+<!-- Last Updated: 2025-12-12 -->
 
 ## 目的
 

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -166,8 +166,8 @@ infrastructure/ # インフラストラクチャ
 
 ```typescript
 // 1. 外部ライブラリ
-import { sum } from 'lodash-es'
 import { object } from 'valibot'
+import { createI18n } from 'i18next'
 
 // 2. 内部パッケージ
 import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly'

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -1,6 +1,6 @@
 # Technology Stack
 
-_Last Updated: 2025-12-12_
+<!-- Last Updated: 2025-12-12 -->
 
 ## Recent Changes
 

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -1,5 +1,12 @@
 # Technology Stack
 
+_Last Updated: 2025-12-12_
+
+## Recent Changes
+
+- **2025-12-12**: Zod → Valibot移行（軽量化とパフォーマンス向上）、lodash削除
+- **2025-12-12**: Node.js 24.11.1、pnpm 10.24.0、Vitest 4.xへ更新
+
 ## Architecture Overview
 
 モダンなJavaScript/TypeScriptエコシステムをベースとした、monorepo構成のWebアプリケーション。フロントエンド中心のアーキテクチャで、静的サイト生成とクライアントサイドレンダリングのハイブリッド構成。
@@ -22,7 +29,7 @@
 
 - **Svelte Stores**: リアクティブ状態管理
 - **Dexie**: IndexedDBラッパーライブラリ（データ永続化）
-- **Zod**: スキーマバリデーション
+- **Valibot**: スキーマバリデーション（軽量・高性能なZod代替）
 
 ### Internationalization
 
@@ -33,8 +40,8 @@
 
 ### Package Management
 
-- **pnpm 10.17.1**: パッケージマネージャー
-- **Node.js 22.19.0**: ランタイム要求バージョン
+- **pnpm 10.24.0**: パッケージマネージャー
+- **Node.js 24.11.1**: ランタイム要求バージョン
 
 ### Monorepo Management
 
@@ -170,4 +177,5 @@ git push origin v1.2.3  # タグプッシュ
 - **Svelte**: ~5.x
 - **TypeScript**: ~5.9.x
 - **Vite**: ~7.x
-- **Vitest**: ~3.x
+- **Vitest**: ~4.x
+- **Valibot**: ~1.x

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -26,6 +26,14 @@ export default [
       },
     },
   },
+  {
+    files: ['**/*.svelte.ts', '**/*.svelte.js'],
+    languageOptions: {
+      parserOptions: {
+        parser: tsParser,
+      },
+    },
+  },
   ...importRules({
     pathGroups: [
       {

--- a/packages/web/src/lib/components/language/LanguageForm.svelte
+++ b/packages/web/src/lib/components/language/LanguageForm.svelte
@@ -3,7 +3,7 @@
   import {
     changeLanguage,
     getCurrentLanguage,
-  } from '$lib/store/language/language-store'
+  } from '$lib/store/language/language-store.svelte'
 
   import { getContext } from 'svelte'
 

--- a/packages/web/src/lib/components/language/LanguageForm.svelte
+++ b/packages/web/src/lib/components/language/LanguageForm.svelte
@@ -10,28 +10,20 @@
   const i18n = getContext<I18NextStore>('i18n')
 
   // グローバルストアから現在の言語設定を取得
-  let language: string = $state(getCurrentLanguage())
+  // $state のため、リアクティブに追跡される
+  let language = $derived.by(() => getCurrentLanguage())
 
-  const languages = (() => {
-    const defLng = (opt: { value: string; label: string }) => ({
-      ...opt,
-      isSelected: () => language === opt.value,
-    })
-
-    return [
-      defLng({ value: 'ja', label: '日本語' }),
-      defLng({ value: 'en', label: 'English' }),
-    ]
-  })()
+  const languages = [
+    { value: 'ja', label: '日本語' },
+    { value: 'en', label: 'English' },
+  ]
 
   // handler
   function onChange(e: Event) {
     const target = e.target as HTMLInputElement
 
-    language = target.value
-
     // グローバルストアとURLクエリの両方を更新
-    changeLanguage(language)
+    changeLanguage(target.value)
   }
 </script>
 
@@ -41,9 +33,9 @@
       {$i18n.t('language.label', { ns: 'page/index' })}
     </label>
     :
-    <select id="change-language" onchange={onChange} bind:value={language}>
+    <select id="change-language" onchange={onChange} value={language}>
       {#each languages as lng (lng.value)}
-        <option value={lng.value} selected={lng.isSelected()}>
+        <option value={lng.value}>
           {lng.label}
         </option>
       {/each}

--- a/packages/web/src/lib/components/language/LanguageForm.svelte
+++ b/packages/web/src/lib/components/language/LanguageForm.svelte
@@ -1,30 +1,16 @@
 <script lang="ts">
   import type { I18NextStore } from '$lib/i18n/define'
-  import { useWithEnableState } from '$lib/ssg/safety-reference'
+  import {
+    changeLanguage,
+    getCurrentLanguage,
+  } from '$lib/store/language/language-store'
 
-  import { getContext, onMount } from 'svelte'
-  import { SvelteURL } from 'svelte/reactivity'
-
-  interface Props {
-    onUpdate?: (search: string) => void
-  }
-
-  let { onUpdate }: Props = $props()
+  import { getContext } from 'svelte'
 
   const i18n = getContext<I18NextStore>('i18n')
 
-  const defaultLanguage: string = 'ja'
-  const languageQuery: string = 'lng'
-  const serializeLanguage = useWithEnableState(setLanguageQuery)
-
-  // state
-  let language: string = $state(defaultLanguage)
-
-  onMount(() => {
-    initialize()
-
-    serializeLanguage.enable()
-  })
+  // グローバルストアから現在の言語設定を取得
+  let language: string = $state(getCurrentLanguage())
 
   const languages = (() => {
     const defLng = (opt: { value: string; label: string }) => ({
@@ -44,26 +30,8 @@
 
     language = target.value
 
-    $i18n.changeLanguage(language)
-
-    serializeLanguage.run()
-  }
-
-  // setup
-  function initialize() {
-    const url = new URL(location.href)
-
-    language = url.searchParams.get(languageQuery) || defaultLanguage
-  }
-  function setLanguageQuery() {
-    const url = new SvelteURL(location.href)
-    const query = url.searchParams
-
-    query.set(languageQuery, language)
-    url.search = query.toString()
-
-    history.pushState({}, '', url)
-    onUpdate?.(url.search)
+    // グローバルストアとURLクエリの両方を更新
+    changeLanguage(language)
   }
 </script>
 

--- a/packages/web/src/lib/store/language/language-store.svelte.spec.ts
+++ b/packages/web/src/lib/store/language/language-store.svelte.spec.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock $app modules - must be defined before imports
+vi.mock('$app/navigation', () => ({
+  pushState: vi.fn(),
+}))
+
+vi.mock('$app/state', () => ({
+  page: { url: new URL('http://localhost/') },
+}))
+
+// Mock i18next
+vi.mock('i18next', () => ({
+  default: {
+    changeLanguage: vi.fn(),
+  },
+}))
+
+import {
+  changeLanguage,
+  getCurrentLanguage,
+  initializeLanguageFromQuery,
+  syncLanguageFromQuery,
+} from './language-store.svelte'
+
+import { pushState } from '$app/navigation'
+import { page } from '$app/state'
+import _i18next from 'i18next'
+
+const mockPushState = pushState as ReturnType<typeof vi.fn>
+const mockPage = page as { url: URL }
+const mockI18nextChangeLanguage = _i18next.changeLanguage as ReturnType<
+  typeof vi.fn
+>
+
+describe('language-store', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks()
+    // Reset page.url to default
+    mockPage.url = new URL('http://localhost/')
+  })
+
+  describe('getCurrentLanguage', () => {
+    it('初期状態ではデフォルト言語(ja)を返すこと', () => {
+      // 初期化前の状態をテスト
+      const language = getCurrentLanguage()
+      expect(language).toBe('ja')
+    })
+
+    it('initializeLanguageFromQueryで設定した言語を返すこと', () => {
+      const url = new URL('http://localhost/?lng=en')
+      initializeLanguageFromQuery(url)
+
+      const language = getCurrentLanguage()
+      expect(language).toBe('en')
+    })
+  })
+
+  describe('initializeLanguageFromQuery', () => {
+    it('URLクエリパラメータから言語設定を初期化すること', () => {
+      const url = new URL('http://localhost/?lng=en')
+
+      initializeLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('en')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('en')
+    })
+
+    it('lngパラメータがない場合はデフォルト言語(ja)を使用すること', () => {
+      const url = new URL('http://localhost/')
+
+      initializeLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+    })
+
+    it('lngパラメータが空文字の場合はデフォルト言語(ja)を使用すること', () => {
+      const url = new URL('http://localhost/?lng=')
+
+      initializeLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+    })
+  })
+
+  describe('changeLanguage', () => {
+    beforeEach(() => {
+      // changeLanguageの前にinitializeする
+      const url = new URL('http://localhost/?lng=ja')
+      initializeLanguageFromQuery(url)
+      mockPage.url = url
+      vi.clearAllMocks()
+    })
+
+    it('言語設定を変更すること', () => {
+      changeLanguage('en')
+
+      expect(getCurrentLanguage()).toBe('en')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('en')
+    })
+
+    it('URLクエリパラメータに言語を反映すること', () => {
+      changeLanguage('en')
+
+      expect(mockPushState).toHaveBeenCalledTimes(1)
+      const [url] = mockPushState.mock.calls[0]
+      expect(url.searchParams.get('lng')).toBe('en')
+    })
+
+    it('既存のクエリパラメータを保持すること', () => {
+      mockPage.url = new URL('http://localhost/?lng=ja&foo=bar')
+
+      changeLanguage('en')
+
+      const [url] = mockPushState.mock.calls[0]
+      expect(url.searchParams.get('lng')).toBe('en')
+      expect(url.searchParams.get('foo')).toBe('bar')
+    })
+
+    it('同じ言語に変更しても問題なく動作すること', () => {
+      changeLanguage('ja')
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+      expect(mockPushState).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('syncLanguageFromQuery', () => {
+    beforeEach(() => {
+      // 初期状態を設定
+      const url = new URL('http://localhost/?lng=ja')
+      initializeLanguageFromQuery(url)
+      vi.clearAllMocks()
+    })
+
+    it('URLの言語設定と現在の言語が異なる場合に同期すること', () => {
+      const url = new URL('http://localhost/?lng=en')
+
+      syncLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('en')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('en')
+    })
+
+    it('URLの言語設定と現在の言語が同じ場合は何もしないこと', () => {
+      const url = new URL('http://localhost/?lng=ja')
+
+      syncLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).not.toHaveBeenCalled()
+    })
+
+    it('lngパラメータがない場合はデフォルト言語(ja)に同期すること', () => {
+      // 現在の言語をenに変更
+      changeLanguage('en')
+      vi.clearAllMocks()
+
+      const url = new URL('http://localhost/')
+
+      syncLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+    })
+
+    it('lngパラメータが空文字の場合はデフォルト言語(ja)に同期すること', () => {
+      // 現在の言語をenに変更
+      changeLanguage('en')
+      vi.clearAllMocks()
+
+      const url = new URL('http://localhost/?lng=')
+
+      syncLanguageFromQuery(url)
+
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+    })
+  })
+
+  describe('統合シナリオ', () => {
+    it('初期化→変更→同期のフロー全体が正しく動作すること', () => {
+      // 1. アプリケーション起動時の初期化
+      const initialUrl = new URL('http://localhost/?lng=ja')
+      initializeLanguageFromQuery(initialUrl)
+      expect(getCurrentLanguage()).toBe('ja')
+
+      // 2. ユーザーが言語を変更
+      mockPage.url = initialUrl
+      vi.clearAllMocks()
+      changeLanguage('en')
+      expect(getCurrentLanguage()).toBe('en')
+      expect(mockPushState).toHaveBeenCalledTimes(1)
+
+      // 3. ブラウザバックで戻る（popstate）
+      vi.clearAllMocks()
+      const backUrl = new URL('http://localhost/?lng=ja')
+      syncLanguageFromQuery(backUrl)
+      expect(getCurrentLanguage()).toBe('ja')
+      expect(mockI18nextChangeLanguage).toHaveBeenCalledWith('ja')
+    })
+  })
+})

--- a/packages/web/src/lib/store/language/language-store.svelte.spec.ts
+++ b/packages/web/src/lib/store/language/language-store.svelte.spec.ts
@@ -1,5 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
 // Mock $app modules - must be defined before imports
 vi.mock('$app/navigation', () => ({
   pushState: vi.fn(),
@@ -16,6 +14,9 @@ vi.mock('i18next', () => ({
   },
 }))
 
+import _i18next from 'i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
   changeLanguage,
   getCurrentLanguage,
@@ -25,7 +26,6 @@ import {
 
 import { pushState } from '$app/navigation'
 import { page } from '$app/state'
-import _i18next from 'i18next'
 
 const mockPushState = pushState as ReturnType<typeof vi.fn>
 const mockPage = page as { url: URL }

--- a/packages/web/src/lib/store/language/language-store.svelte.ts
+++ b/packages/web/src/lib/store/language/language-store.svelte.ts
@@ -1,4 +1,5 @@
 import _i18next from 'i18next'
+import { SvelteURL } from 'svelte/reactivity'
 
 import { pushState } from '$app/navigation'
 import { page } from '$app/state'
@@ -44,7 +45,7 @@ export function changeLanguage(lng: string): void {
   _i18next.changeLanguage(lng)
 
   // URLクエリパラメータに反映
-  const url = new URL(page.url)
+  const url = new SvelteURL(page.url)
   url.searchParams.set(LANGUAGE_QUERY_KEY, lng)
   pushState(url, {})
 }

--- a/packages/web/src/lib/store/language/language-store.svelte.ts
+++ b/packages/web/src/lib/store/language/language-store.svelte.ts
@@ -7,9 +7,6 @@ import { page } from '$app/state'
 const LANGUAGE_QUERY_KEY = 'lng'
 const DEFAULT_LANGUAGE = 'ja'
 
-// 現在の言語設定を保持する $state
-// LanguageForm で bind:value を使うため、$state が必要
-// リアクティビティの循環は、URL更新時に untrack を使って回避する
 let currentLanguage = $state(DEFAULT_LANGUAGE)
 
 /**

--- a/packages/web/src/lib/store/language/language-store.ts
+++ b/packages/web/src/lib/store/language/language-store.ts
@@ -1,0 +1,66 @@
+import _i18next from 'i18next'
+
+import { pushState } from '$app/navigation'
+import { page } from '$app/state'
+
+const LANGUAGE_QUERY_KEY = 'lng'
+const DEFAULT_LANGUAGE = 'ja'
+
+// 現在の言語設定を保持する $state
+// $state を使わない理由: リアクティビティの循環を避けるため
+// (assembly の appQuery と同じパターン)
+let currentLanguage = DEFAULT_LANGUAGE
+
+/**
+ * 現在の言語設定を取得する
+ */
+export function getCurrentLanguage(): string {
+  return currentLanguage
+}
+
+/**
+ * URLクエリパラメータから言語設定を初期化する
+ *
+ * アプリケーション起動時（afterNavigate type='enter'）に呼び出す
+ *
+ * @param url - 現在のURL
+ */
+export function initializeLanguageFromQuery(url: URL): void {
+  const lng = url.searchParams.get(LANGUAGE_QUERY_KEY) || DEFAULT_LANGUAGE
+
+  currentLanguage = lng
+  _i18next.changeLanguage(lng)
+}
+
+/**
+ * 言語設定を変更し、URLクエリパラメータに反映する
+ *
+ * LanguageFormなどのUIコンポーネントから呼び出す
+ *
+ * @param lng - 新しい言語コード（'ja' | 'en'）
+ */
+export function changeLanguage(lng: string): void {
+  currentLanguage = lng
+  _i18next.changeLanguage(lng)
+
+  // URLクエリパラメータに反映
+  const url = new URL(page.url)
+  url.searchParams.set(LANGUAGE_QUERY_KEY, lng)
+  pushState(url, {})
+}
+
+/**
+ * URLクエリパラメータから言語設定を同期する
+ *
+ * ブラウザバック/フォワード（popstate）時に呼び出す
+ *
+ * @param url - 現在のURL
+ */
+export function syncLanguageFromQuery(url: URL): void {
+  const lng = url.searchParams.get(LANGUAGE_QUERY_KEY) || DEFAULT_LANGUAGE
+
+  if (lng !== currentLanguage) {
+    currentLanguage = lng
+    _i18next.changeLanguage(lng)
+  }
+}

--- a/packages/web/src/lib/store/language/language-store.ts
+++ b/packages/web/src/lib/store/language/language-store.ts
@@ -7,9 +7,9 @@ const LANGUAGE_QUERY_KEY = 'lng'
 const DEFAULT_LANGUAGE = 'ja'
 
 // 現在の言語設定を保持する $state
-// $state を使わない理由: リアクティビティの循環を避けるため
-// (assembly の appQuery と同じパターン)
-let currentLanguage = DEFAULT_LANGUAGE
+// LanguageForm で bind:value を使うため、$state が必要
+// リアクティビティの循環は、URL更新時に untrack を使って回避する
+let currentLanguage = $state(DEFAULT_LANGUAGE)
 
 /**
  * 現在の言語設定を取得する

--- a/packages/web/src/lib/store/query/query-merge.spec.ts
+++ b/packages/web/src/lib/store/query/query-merge.spec.ts
@@ -1,25 +1,26 @@
-
-import { assemblyToSearchV2 } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
-import { genAssembly } from "@ac6_assemble_tool/core/spec-helper/property-generator"
+import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
+import { genAssembly } from '@ac6_assemble_tool/core/spec-helper/property-generator'
 import { it as fcit } from '@fast-check/vitest'
-import { describe, expect } from "vitest"
+import { describe, expect } from 'vitest'
 
-import { mergeAssemblyParams } from "./query-merge"
+import { mergeAssemblyParams } from './query-merge'
 
 describe('query-merge', () => {
   describe(mergeAssemblyParams, () => {
-    fcit.prop([genAssembly()])('アセンブリ系パラメータのみをマージし、他のクエリを保持する', (assembly) => {
-      const assemblyParams = assemblyToSearchV2(assembly)
-      const current = new URLSearchParams('lng=ja&foo=bar')
+    fcit.prop([genAssembly()])(
+      'アセンブリ系パラメータのみをマージし、他のクエリを保持する',
+      (assembly) => {
+        const assemblyParams = assemblyToSearchV2(assembly)
+        const current = new URLSearchParams('lng=ja&foo=bar')
 
-      mergeAssemblyParams(current, assemblyParams)
+        mergeAssemblyParams(current, assemblyParams)
 
-      expect(current.get('lng')).toBe('ja')
-      expect(current.get('foo')).toBe('bar')
-      assemblyParams.forEach((value, key) => {
-        expect(current.get(key)).toBe(value)
-      })
-
-    })
+        expect(current.get('lng')).toBe('ja')
+        expect(current.get('foo')).toBe('bar')
+        assemblyParams.forEach((value, key) => {
+          expect(current.get(key)).toBe(value)
+        })
+      },
+    )
   })
 })

--- a/packages/web/src/lib/store/query/query-merge.spec.ts
+++ b/packages/web/src/lib/store/query/query-merge.spec.ts
@@ -1,0 +1,25 @@
+
+import { assemblyToSearchV2 } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
+import { genAssembly } from "@ac6_assemble_tool/core/spec-helper/property-generator"
+import { it as fcit } from '@fast-check/vitest'
+import { describe, expect } from "vitest"
+
+import { mergeAssemblyParams } from "./query-merge"
+
+describe('query-merge', () => {
+  describe(mergeAssemblyParams, () => {
+    fcit.prop([genAssembly()])('アセンブリ系パラメータのみをマージし、他のクエリを保持する', (assembly) => {
+      const assemblyParams = assemblyToSearchV2(assembly)
+      const current = new URLSearchParams('lng=ja&foo=bar')
+
+      mergeAssemblyParams(current, assemblyParams)
+
+      expect(current.get('lng')).toBe('ja')
+      expect(current.get('foo')).toBe('bar')
+      assemblyParams.forEach((value, key) => {
+        expect(current.get(key)).toBe(value)
+      })
+
+    })
+  })
+})

--- a/packages/web/src/lib/store/query/query-merge.ts
+++ b/packages/web/src/lib/store/query/query-merge.ts
@@ -1,0 +1,15 @@
+import { ASSEMBLY_QUERY_V2_KEYS } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
+
+/**
+ * アセンブリ関連パラメータのみを差し替え、非アセンブリ系のクエリは保持する。
+ */
+export function mergeAssemblyParams(
+  currentParams: URLSearchParams,
+  assemblyParams: URLSearchParams,
+): void {
+  ASSEMBLY_QUERY_V2_KEYS.forEach((key) => currentParams.delete(key))
+
+  assemblyParams.forEach((value, key) => {
+    currentParams.set(key, value)
+  })
+}

--- a/packages/web/src/lib/store/query/query-merge.ts
+++ b/packages/web/src/lib/store/query/query-merge.ts
@@ -1,4 +1,4 @@
-import { ASSEMBLY_QUERY_V2_KEYS } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
+import { ASSEMBLY_QUERY_V2_KEYS } from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
 
 /**
  * アセンブリ関連パラメータのみを差し替え、非アセンブリ系のクエリは保持する。

--- a/packages/web/src/lib/store/query/query-store.spec.ts
+++ b/packages/web/src/lib/store/query/query-store.spec.ts
@@ -1,0 +1,273 @@
+import { genAssembly } from '@ac6_assemble_tool/core/spec-helper/property-generator'
+import { it as fcit } from '@fast-check/vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock $app modules - must be defined before imports
+let mockBrowser = true
+
+vi.mock('$app/navigation', () => ({
+  pushState: vi.fn(),
+}))
+
+vi.mock('$app/state', () => ({
+  page: { url: new URL('http://localhost/') },
+}))
+
+vi.mock('$app/environment', () => ({
+  get browser() {
+    return mockBrowser
+  },
+}))
+
+import { buildQueryFromAssembly, storeAssemblyAsQuery } from './query-store'
+
+import { pushState } from '$app/navigation'
+import { page } from '$app/state'
+
+const mockPushState = pushState as ReturnType<typeof vi.fn>
+const mockPage = page as { url: URL }
+
+describe('query-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPage.url = new URL('http://localhost/')
+    mockBrowser = true
+  })
+
+  describe('buildQueryFromAssembly', () => {
+    describe('ブラウザ環境', () => {
+      fcit.prop([genAssembly()])(
+        'アセンブリから完全なクエリパラメータを生成すること',
+        (assembly) => {
+          const params = buildQueryFromAssembly(assembly)
+
+          expect(params).toBeInstanceOf(URLSearchParams)
+          // アセンブリパラメータが含まれていることを確認
+          expect(params.toString()).toBeTruthy()
+        },
+      )
+
+      fcit.prop([genAssembly()])(
+        '現在のURLクエリパラメータをマージすること',
+        (assembly) => {
+          mockPage.url = new URL('http://localhost/?lng=ja&foo=bar')
+
+          const params = buildQueryFromAssembly(assembly)
+
+          // 既存のパラメータが保持されている
+          expect(params.get('lng')).toBe('ja')
+          expect(params.get('foo')).toBe('bar')
+        },
+      )
+
+      fcit.prop([genAssembly()])(
+        '言語クエリパラメータが保持されること',
+        (assembly) => {
+          mockPage.url = new URL('http://localhost/?lng=en')
+
+          const params = buildQueryFromAssembly(assembly)
+
+          expect(params.get('lng')).toBe('en')
+        },
+      )
+
+      fcit.prop([genAssembly()])(
+        '複数のクエリパラメータが保持されること',
+        (assembly) => {
+          mockPage.url = new URL(
+            'http://localhost/?lng=ja&debug=true&version=1.0',
+          )
+
+          const params = buildQueryFromAssembly(assembly)
+
+          expect(params.get('lng')).toBe('ja')
+          expect(params.get('debug')).toBe('true')
+          expect(params.get('version')).toBe('1.0')
+        },
+      )
+    })
+
+    describe('SSR環境', () => {
+      beforeEach(() => {
+        mockBrowser = false
+      })
+
+      fcit.prop([genAssembly()])(
+        'SSR時でもエラーなくクエリパラメータを生成すること',
+        (assembly) => {
+          const params = buildQueryFromAssembly(assembly)
+
+          expect(params).toBeInstanceOf(URLSearchParams)
+          // アセンブリパラメータが含まれていることを確認
+          expect(params.toString()).toBeTruthy()
+        },
+      )
+
+      fcit.prop([genAssembly()])(
+        'SSR時は空のベースパラメータを使用すること',
+        (assembly) => {
+          mockPage.url = new URL('http://localhost/?lng=ja&foo=bar')
+
+          const params = buildQueryFromAssembly(assembly)
+
+          // SSR時はpage.urlにアクセスしないため、既存パラメータは含まれない
+          expect(params.get('lng')).toBeNull()
+          expect(params.get('foo')).toBeNull()
+          // アセンブリパラメータのみが含まれる
+          expect(params.toString()).toBeTruthy()
+        },
+      )
+    })
+  })
+
+  describe('storeAssemblyAsQuery', () => {
+    beforeEach(() => {
+      mockBrowser = true
+      mockPage.url = new URL('http://localhost/')
+      vi.clearAllMocks()
+    })
+
+    fcit.prop([genAssembly()])(
+      'アセンブリをURLクエリパラメータに保存すること',
+      (assembly) => {
+        vi.clearAllMocks()
+
+        storeAssemblyAsQuery(assembly)
+
+        expect(mockPushState).toHaveBeenCalledTimes(1)
+        const [url, state] = mockPushState.mock.calls[0]
+        expect(url).toMatch(/^\/?/)
+        expect(state).toEqual({})
+      },
+    )
+
+    fcit.prop([genAssembly()])(
+      '現在のパス名を保持すること',
+      (assembly) => {
+        // 各テスト内で元のURLを保存
+        const originalUrl = mockPage.url
+        mockPage.url = new URL('http://localhost/parts-list')
+
+        try {
+          storeAssemblyAsQuery(assembly)
+
+          const [url] = mockPushState.mock.calls[0]
+          expect(url).toMatch(/^\/parts-list\?/)
+        } finally {
+          // 元のURLに戻す
+          mockPage.url = originalUrl
+        }
+      },
+    )
+
+    fcit.prop([genAssembly()])(
+      '既存のクエリパラメータをマージすること',
+      (assembly) => {
+        const originalUrl = mockPage.url
+        mockPage.url = new URL('http://localhost/?lng=ja')
+
+        try {
+          storeAssemblyAsQuery(assembly)
+
+          const [url] = mockPushState.mock.calls[0]
+          // lngパラメータが含まれていることを確認
+          expect(url).toContain('lng=ja')
+        } finally {
+          mockPage.url = originalUrl
+        }
+      },
+    )
+
+    fcit.prop([genAssembly()])(
+      '複数のクエリパラメータを正しく処理すること',
+      (assembly) => {
+        const originalUrl = mockPage.url
+        mockPage.url = new URL('http://localhost/?lng=en&debug=true')
+
+        try {
+          storeAssemblyAsQuery(assembly)
+
+          const [url] = mockPushState.mock.calls[0]
+          expect(url).toContain('lng=en')
+          expect(url).toContain('debug=true')
+        } finally {
+          mockPage.url = originalUrl
+        }
+      },
+    )
+
+    fcit.prop([genAssembly()])(
+      '空のクエリパラメータでも正しく動作すること',
+      (assembly) => {
+        vi.clearAllMocks()
+
+        storeAssemblyAsQuery(assembly)
+
+        expect(mockPushState).toHaveBeenCalledTimes(1)
+        const [url] = mockPushState.mock.calls[0]
+        expect(url).toMatch(/^\/?/)
+      },
+    )
+  })
+
+  describe('統合シナリオ', () => {
+    beforeEach(() => {
+      mockBrowser = true
+      mockPage.url = new URL('http://localhost/')
+      vi.clearAllMocks()
+    })
+
+    fcit.prop([genAssembly()])(
+      'buildQueryFromAssemblyとstoreAssemblyAsQueryが連携して動作すること',
+      (assembly) => {
+        const originalUrl = mockPage.url
+        mockPage.url = new URL('http://localhost/?lng=ja')
+        vi.clearAllMocks()
+
+        try {
+          // 1. クエリを生成
+          const params = buildQueryFromAssembly(assembly)
+          expect(params.get('lng')).toBe('ja')
+
+          // 2. URLに保存
+          storeAssemblyAsQuery(assembly)
+          expect(mockPushState).toHaveBeenCalledTimes(1)
+
+          const [url] = mockPushState.mock.calls[0]
+          expect(url).toContain('lng=ja')
+        } finally {
+          mockPage.url = originalUrl
+        }
+      },
+    )
+
+    fcit.prop([genAssembly()])(
+      '言語切り替えとアセンブリ保存が同時に行われること',
+      (assembly) => {
+        const originalUrl = mockPage.url
+
+        try {
+          // 初期状態: 日本語
+          mockPage.url = new URL('http://localhost/?lng=ja')
+
+          storeAssemblyAsQuery(assembly)
+
+          let [url1] = mockPushState.mock.calls[0]
+          expect(url1).toContain('lng=ja')
+
+          // 言語を英語に変更
+          mockPage.url = new URL('http://localhost/?lng=en')
+          vi.clearAllMocks()
+
+          storeAssemblyAsQuery(assembly)
+
+          let [url2] = mockPushState.mock.calls[0]
+          expect(url2).toContain('lng=en')
+        } finally {
+          mockPage.url = originalUrl
+          vi.clearAllMocks()
+        }
+      },
+    )
+  })
+})

--- a/packages/web/src/lib/store/query/query-store.spec.ts
+++ b/packages/web/src/lib/store/query/query-store.spec.ts
@@ -1,6 +1,6 @@
 import { genAssembly } from '@ac6_assemble_tool/core/spec-helper/property-generator'
 import { it as fcit } from '@fast-check/vitest'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, vi } from 'vitest'
 
 // Mock $app modules - must be defined before imports
 let mockBrowser = true
@@ -141,24 +141,21 @@ describe('query-store', () => {
       },
     )
 
-    fcit.prop([genAssembly()])(
-      '現在のパス名を保持すること',
-      (assembly) => {
-        // 各テスト内で元のURLを保存
-        const originalUrl = mockPage.url
-        mockPage.url = new URL('http://localhost/parts-list')
+    fcit.prop([genAssembly()])('現在のパス名を保持すること', (assembly) => {
+      // 各テスト内で元のURLを保存
+      const originalUrl = mockPage.url
+      mockPage.url = new URL('http://localhost/parts-list')
 
-        try {
-          storeAssemblyAsQuery(assembly)
+      try {
+        storeAssemblyAsQuery(assembly)
 
-          const [url] = mockPushState.mock.calls[0]
-          expect(url).toMatch(/^\/parts-list\?/)
-        } finally {
-          // 元のURLに戻す
-          mockPage.url = originalUrl
-        }
-      },
-    )
+        const [url] = mockPushState.mock.calls[0]
+        expect(url).toMatch(/^\/parts-list\?/)
+      } finally {
+        // 元のURLに戻す
+        mockPage.url = originalUrl
+      }
+    })
 
     fcit.prop([genAssembly()])(
       '既存のクエリパラメータをマージすること',
@@ -252,7 +249,7 @@ describe('query-store', () => {
 
           storeAssemblyAsQuery(assembly)
 
-          let [url1] = mockPushState.mock.calls[0]
+          const [url1] = mockPushState.mock.calls[0]
           expect(url1).toContain('lng=ja')
 
           // 言語を英語に変更
@@ -261,7 +258,7 @@ describe('query-store', () => {
 
           storeAssemblyAsQuery(assembly)
 
-          let [url2] = mockPushState.mock.calls[0]
+          const [url2] = mockPushState.mock.calls[0]
           expect(url2).toContain('lng=en')
         } finally {
           mockPage.url = originalUrl

--- a/packages/web/src/lib/store/query/query-store.ts
+++ b/packages/web/src/lib/store/query/query-store.ts
@@ -6,11 +6,28 @@ import { mergeAssemblyParams } from './query-merge'
 import { pushState } from '$app/navigation'
 import { page } from '$app/state'
 
+/**
+ * アセンブリから完全なクエリパラメータを生成する
+ *
+ * アセンブリのパラメータと現在のURL（言語設定など）をマージして返す
+ *
+ * @param assembly - アセンブリデータ
+ * @returns マージされたURLSearchParams
+ */
+export function buildQueryFromAssembly(assembly: Assembly): URLSearchParams {
+  const assemblyParams = assemblyToSearchV2(assembly)
+  const mergedParams = new URLSearchParams(page.url.searchParams)
+  mergeAssemblyParams(mergedParams, assemblyParams)
+
+  return mergedParams
+}
+
+/**
+ * アセンブリをURLクエリパラメータに保存する
+ *
+ * @param assembly - アセンブリデータ
+ */
 export function storeAssemblyAsQuery(assembly: Assembly): void {
-  const appQuery = assemblyToSearchV2(assembly)
-
-  const q = new URLSearchParams(page.url.searchParams)
-  mergeAssemblyParams(q, new URLSearchParams(appQuery))
-
+  const q = buildQueryFromAssembly(assembly)
   pushState(`${page.url.pathname}?${q.toString()}`, {})
 }

--- a/packages/web/src/lib/store/query/query-store.ts
+++ b/packages/web/src/lib/store/query/query-store.ts
@@ -3,8 +3,8 @@ import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/a
 
 import { mergeAssemblyParams } from './query-merge'
 
-import { pushState } from '$app/navigation'
 import { browser } from '$app/environment'
+import { pushState } from '$app/navigation'
 import { page } from '$app/state'
 
 /**

--- a/packages/web/src/lib/store/query/query-store.ts
+++ b/packages/web/src/lib/store/query/query-store.ts
@@ -4,6 +4,7 @@ import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/a
 import { mergeAssemblyParams } from './query-merge'
 
 import { pushState } from '$app/navigation'
+import { browser } from '$app/environment'
 import { page } from '$app/state'
 
 /**
@@ -16,7 +17,10 @@ import { page } from '$app/state'
  */
 export function buildQueryFromAssembly(assembly: Assembly): URLSearchParams {
   const assemblyParams = assemblyToSearchV2(assembly)
-  const mergedParams = new URLSearchParams(page.url.searchParams)
+  // SSR時はpage.urlにアクセスできないため、空のパラメータを使用
+  const mergedParams = browser
+    ? new URLSearchParams(page.url.searchParams)
+    : new URLSearchParams()
   mergeAssemblyParams(mergedParams, assemblyParams)
 
   return mergedParams

--- a/packages/web/src/lib/store/query/query-store.ts
+++ b/packages/web/src/lib/store/query/query-store.ts
@@ -1,11 +1,10 @@
+import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly'
+import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
 
-import { assemblyToSearchV2 } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
+import { mergeAssemblyParams } from './query-merge'
 
-import { mergeAssemblyParams } from "./query-merge"
-
-import { pushState } from "$app/navigation"
-import { page } from "$app/state"
-import type { Assembly } from "@ac6_assemble_tool/core/assembly/assembly"
+import { pushState } from '$app/navigation'
+import { page } from '$app/state'
 
 export function storeAssemblyAsQuery(assembly: Assembly): void {
   const appQuery = assemblyToSearchV2(assembly)

--- a/packages/web/src/lib/store/query/query-store.ts
+++ b/packages/web/src/lib/store/query/query-store.ts
@@ -1,0 +1,17 @@
+
+import { assemblyToSearchV2 } from "@ac6_assemble_tool/core/assembly/serialize/as-query-v2"
+
+import { mergeAssemblyParams } from "./query-merge"
+
+import { pushState } from "$app/navigation"
+import { page } from "$app/state"
+import type { Assembly } from "@ac6_assemble_tool/core/assembly/assembly"
+
+export function storeAssemblyAsQuery(assembly: Assembly): void {
+  const appQuery = assemblyToSearchV2(assembly)
+
+  const q = new URLSearchParams(page.url.searchParams)
+  mergeAssemblyParams(q, new URLSearchParams(appQuery))
+
+  pushState(`${page.url.pathname}?${q.toString()}`, {})
+}

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -8,8 +8,11 @@
   import ErrorModal from '$lib/components/modal/ErrorModal.svelte'
   import i18n from '$lib/i18n/define'
   import { useWithEnableState } from '$lib/ssg/safety-reference'
-  import { syncLanguageFromQuery } from '$lib/store/language/language-store'
-  import { storeAssemblyAsQuery } from '$lib/store/query/query-store'
+  import { syncLanguageFromQuery } from '$lib/store/language/language-store.svelte'
+  import {
+    buildQueryFromAssembly,
+    storeAssemblyAsQuery,
+  } from '$lib/store/query/query-store'
 
   import {
     type Assembly,
@@ -20,7 +23,6 @@
   import { changeAssemblyCommand } from '@ac6_assemble_tool/core/assembly/command/change-assembly'
   import { LockedParts } from '@ac6_assemble_tool/core/assembly/random/lock'
   import { RandomAssembly } from '@ac6_assemble_tool/core/assembly/random/random-assembly'
-  import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
   import {
     type Candidates,
     type OrderParts,
@@ -78,8 +80,9 @@
   let errorMessage = $state<string[]>([])
 
   let assembly = $state<Assembly>(initializeAssembly(candidates))
+  // アセンブリと現在のURLクエリ（言語設定など）をマージしてパーツ一覧へのリンクを生成
   let navToPartsList = $derived(
-    `/parts-list?${assemblyToSearchV2(assembly).toString()}`,
+    `/parts-list?${buildQueryFromAssembly(assembly).toString()}`,
   )
 
   let queuedUrl: URL | null = null

--- a/packages/web/src/lib/view/index/Index.svelte
+++ b/packages/web/src/lib/view/index/Index.svelte
@@ -8,6 +8,7 @@
   import ErrorModal from '$lib/components/modal/ErrorModal.svelte'
   import i18n from '$lib/i18n/define'
   import { useWithEnableState } from '$lib/ssg/safety-reference'
+  import { syncLanguageFromQuery } from '$lib/store/language/language-store'
   import { storeAssemblyAsQuery } from '$lib/store/query/query-store'
 
   import {
@@ -85,7 +86,6 @@
 
   const orderParts: OrderParts = $derived(defineOrder(orders))
 
-  // svelte-ignore state_referenced_locally
   const serializeAssembly = useWithEnableState(() => {
     storeAssemblyAsQuery(assembly)
 
@@ -199,6 +199,11 @@
     logger.debug('on popstate', {
       search: page.url.search,
     })
+
+    // 言語設定を同期
+    syncLanguageFromQuery(page.url)
+
+    // アセンブリを再構築
     const result = buildAssemblyFromQuery(
       page.url.searchParams,
       partsPoolState.candidates,

--- a/packages/web/src/lib/view/index/interaction/assembly-from-query.spec.ts
+++ b/packages/web/src/lib/view/index/interaction/assembly-from-query.spec.ts
@@ -26,5 +26,4 @@ describe('assembly-from-query', () => {
     expect(migratedParams).toBeUndefined()
     expect(assemblyToSearchV2(assembly).toString()).toBe(params.toString())
   })
-
 })

--- a/packages/web/src/lib/view/index/interaction/assembly-from-query.spec.ts
+++ b/packages/web/src/lib/view/index/interaction/assembly-from-query.spec.ts
@@ -4,10 +4,7 @@ import { assemblyToSearchV2 } from '@ac6_assemble_tool/core/assembly/serialize/a
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { initializeAssembly } from './assembly'
-import {
-  buildAssemblyFromQuery,
-  mergeAssemblyParams,
-} from './assembly-from-query'
+import { buildAssemblyFromQuery } from './assembly-from-query'
 
 describe('assembly-from-query', () => {
   const candidates = regulation.candidates
@@ -30,17 +27,4 @@ describe('assembly-from-query', () => {
     expect(assemblyToSearchV2(assembly).toString()).toBe(params.toString())
   })
 
-  it('アセンブリ系パラメータのみをマージし、他のクエリを保持する', () => {
-    const baseAssembly = initializeAssembly(candidates)
-    const assemblyParams = assemblyToSearchV2(baseAssembly)
-    const current = new URLSearchParams('lng=ja&foo=bar')
-
-    mergeAssemblyParams(current, assemblyParams)
-
-    expect(current.get('lng')).toBe('ja')
-    expect(current.get('foo')).toBe('bar')
-    assemblyParams.forEach((value, key) => {
-      expect(current.get(key)).toBe(value)
-    })
-  })
 })

--- a/packages/web/src/lib/view/index/interaction/assembly-from-query.ts
+++ b/packages/web/src/lib/view/index/interaction/assembly-from-query.ts
@@ -2,10 +2,7 @@ import {
   createAssembly,
   type Assembly,
 } from '@ac6_assemble_tool/core/assembly/assembly'
-import {
-  searchToAssemblyV2,
-  ASSEMBLY_QUERY_V2_KEYS,
-} from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
+import { searchToAssemblyV2 } from '@ac6_assemble_tool/core/assembly/serialize/as-query-v2'
 import { VersionMigration } from '@ac6_assemble_tool/core/assembly/version-migration'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 
@@ -35,18 +32,4 @@ export const buildAssemblyFromQuery = (
     assembly,
     migratedParams: changed ? convertedParams : undefined,
   }
-}
-
-/**
- * アセンブリ関連パラメータのみを差し替え、非アセンブリ系のクエリは保持する。
- */
-export const mergeAssemblyParams = (
-  currentParams: URLSearchParams,
-  assemblyParams: URLSearchParams,
-): void => {
-  ASSEMBLY_QUERY_V2_KEYS.forEach((key) => currentParams.delete(key))
-
-  assemblyParams.forEach((value, key) => {
-    currentParams.set(key, value)
-  })
 }

--- a/packages/web/src/lib/view/index/interaction/bootstrap.ts
+++ b/packages/web/src/lib/view/index/interaction/bootstrap.ts
@@ -1,10 +1,9 @@
+import { mergeAssemblyParams } from '$lib/store/query/query-merge'
+
 import type { Assembly } from '@ac6_assemble_tool/core/assembly/assembly'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
 
-import {
-  buildAssemblyFromQuery,
-  mergeAssemblyParams,
-} from './assembly-from-query'
+import { buildAssemblyFromQuery } from './assembly-from-query'
 import {
   derivePartsPool,
   type PartsPoolRestrictions,

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -9,12 +9,15 @@
   import i18n from '$lib/i18n/define'
   import { extractChars } from '$lib/i18n/extract-chars'
   import { resources } from '$lib/i18n/resources'
+  import { initializeLanguageFromQuery } from '$lib/store/language/language-store'
   import { appVersion } from '$lib/utils/app-version'
   import { withPageQuery } from '$lib/utils/page-query'
 
   import { setLogLevel } from '@ac6_assemble_tool/shared/logger'
   import { setContext } from 'svelte'
 
+  import { afterNavigate } from '$app/navigation'
+  import { page } from '$app/state'
   import {
     PUBLIC_LOG_LEVEL,
     PUBLIC_REPORT_BUG_URL,
@@ -25,6 +28,13 @@
 
   setContext('i18n', i18n)
   setLogLevel(PUBLIC_LOG_LEVEL || 'info')
+
+  // アプリケーション起動時に言語設定を初期化
+  afterNavigate(({ type }) => {
+    if (type === 'enter') {
+      initializeLanguageFromQuery(page.url)
+    }
+  })
 
   const jaText = extractChars(resources.ja)
   function onFontLoad(this: HTMLLinkElement): void {

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
   import i18n from '$lib/i18n/define'
   import { extractChars } from '$lib/i18n/extract-chars'
   import { resources } from '$lib/i18n/resources'
-  import { initializeLanguageFromQuery } from '$lib/store/language/language-store'
+  import { initializeLanguageFromQuery } from '$lib/store/language/language-store.svelte'
   import { appVersion } from '$lib/utils/app-version'
   import { withPageQuery } from '$lib/utils/page-query'
 


### PR DESCRIPTION
## Summary

このPRでは、以下の3つの主要な改善を実施しました:

1. **無限ループの修正**: アセンブリ変更時のURL更新によって発生していた無限ループを、リアクティビティフローを再設計することで解決
2. **言語設定のグローバルストア化**: 各コンポーネントでクエリから読み込む方式から、グローバルストアで一元管理する方式に変更
3. **クエリパラメータマージロジックの統合**: 散在していたクエリマージ処理を`buildQueryFromAssembly()`関数に集約

## Changes

### 1. Infinite Loop Fix

**問題**:
- `$effect`がassemblyの変更を検知 → `appQuery` ($state)を更新 → `navToPartsList`の`$derived`が再評価 → 再度`$effect`がトリガー、という循環が発生

**解決策**:
- `appQuery`を`$state`変数から削除
- `navToPartsList`を`buildQueryFromAssembly()`を使って直接assemblyから導出するように変更
- これにより中間的な`$state`を経由せず、循環依存を解消

**変更ファイル**:
- [packages/web/src/lib/view/index/Index.svelte](packages/web/src/lib/view/index/Index.svelte)
- [packages/web/src/lib/store/query/query-store.ts](packages/web/src/lib/store/query/query-store.ts)

### 2. Global Language Store

**実装内容**:
- `language-store.svelte.ts`を新規作成し、`$state`runeを使用してグローバルな言語設定を管理
- アプリケーション起動時(`afterNavigate type='enter'`)にURLクエリから言語設定を初期化
- 言語変更時にグローバルストアとURLクエリの両方を同期
- ブラウザバック/フォワード時にも言語設定を同期

**技術的詳細**:
- `.svelte.ts`拡張子を使用することで、コンポーネント外で`$state`runeを使用可能に
- `SvelteURL`を使用してSvelte5のリアクティビティに対応
- `$derived.by()`でコンポーネントが言語変更を追跡

**変更ファイル**:
- [packages/web/src/lib/store/language/language-store.svelte.ts](packages/web/src/lib/store/language/language-store.svelte.ts) (新規)
- [packages/web/src/lib/components/language/LanguageForm.svelte](packages/web/src/lib/components/language/LanguageForm.svelte)
- [packages/web/src/routes/+layout.svelte](packages/web/src/routes/+layout.svelte)

### 3. Query Parameter Consolidation

**実装内容**:
- `buildQueryFromAssembly()`関数を作成し、アセンブリからクエリパラメータを構築するロジックを一箇所に集約
- `storeAssemblyAsQuery()`と`navToPartsList`の両方で同じ関数を使用
- これにより、クエリマージロジックの重複を排除し、保守性を向上

**変更ファイル**:
- [packages/web/src/lib/store/query/query-store.ts](packages/web/src/lib/store/query/query-store.ts)
- [packages/web/src/lib/store/query/query-merge.ts](packages/web/src/lib/store/query/query-merge.ts) (新規)
- [packages/web/src/lib/store/query/query-merge.spec.ts](packages/web/src/lib/store/query/query-merge.spec.ts) (新規)

### 4. ESLint Configuration

`.svelte.ts`ファイルのサポートを追加:

```javascript
{
  files: ['**/*.svelte.ts', '**/*.svelte.js'],
  languageOptions: {
    parserOptions: {
      parser: tsParser,
    },
  },
}
```

**変更ファイル**:
- [packages/web/eslint.config.js](packages/web/eslint.config.js)

## Test Plan

- [x] アセンブリページで言語を変更し、URLクエリとUIの両方に反映されることを確認
- [x] ブラウザリロード時に言語設定が保持されることを確認
- [x] アセンブリページからパーツ一覧ページへ移動時に言語クエリが保持されることを確認
- [x] ブラウザバック/フォワード時に言語設定が同期されることを確認
- [x] アセンブリ変更時に無限ループが発生しないことを確認
- [x] Lint・型チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)