### PR TITLE
武器未装備禁止を部位別トグルに分割（右腕/左腕/右肩/左肩/コア拡張）

### DIFF
--- a/.changeset/humble-hornets-itch.md
+++ b/.changeset/humble-hornets-itch.md
@@ -1,0 +1,7 @@
+---
+"@ac6_assemble_tool/core": minor
+"@ac6_assemble_tool/web": minor
+---
+
+support each disallow-not-equipped
+  

--- a/.changeset/stale-dodos-rush.md
+++ b/.changeset/stale-dodos-rush.md
@@ -1,0 +1,7 @@
+---
+"@ac6_assemble_tool/core": minor
+"@ac6_assemble_tool/web": minor
+---
+
+support each deny-not-equipped
+  

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/core
 
 ## 1.4.0
+
 ### Minor Changes
-
-
 
 - [#1048](https://github.com/tooppoo/ac6_assemble_tool/pull/1048) [`8a4064c`](https://github.com/tooppoo/ac6_assemble_tool/commit/8a4064c0ca6a70b9c9aeb88c39cdb6e3bf825e56) Thanks [@tooppoo](https://github.com/tooppoo)! - support DisallowNotEquipped
 

--- a/packages/core/src/assembly/random/validator/validators.spec.ts
+++ b/packages/core/src/assembly/random/validator/validators.spec.ts
@@ -346,7 +346,9 @@ describe('validator', () => {
           assembly[slot] = notEquippedBySlot[slot]
 
           expect(
-            Result.isSuccess(disallowNotEquippedInSlot(slot).validate(assembly)),
+            Result.isSuccess(
+              disallowNotEquippedInSlot(slot).validate(assembly),
+            ),
           ).toBe(false)
         },
       )
@@ -355,7 +357,9 @@ describe('validator', () => {
         'should be valid when the slot is equipped',
         (assembly) => {
           expect(
-            Result.isSuccess(disallowNotEquippedInSlot(slot).validate(assembly)),
+            Result.isSuccess(
+              disallowNotEquippedInSlot(slot).validate(assembly),
+            ),
           ).toBe(true)
         },
       )

--- a/packages/core/src/assembly/random/validator/validators.spec.ts
+++ b/packages/core/src/assembly/random/validator/validators.spec.ts
@@ -4,6 +4,7 @@ import {
   armNotEquipped,
   backNotEquipped,
   type BackNotEquipped,
+  expansionNotEquipped,
 } from '@ac6_assemble_tool/parts/not-equipped'
 import { notEquipped as notEquippedClass } from '@ac6_assemble_tool/parts/types/base/classification'
 import type { Candidates } from '@ac6_assemble_tool/parts/types/candidates'
@@ -16,7 +17,8 @@ import { afterEach, beforeEach, describe, expect } from 'vitest'
 import {
   disallowArmsLoadOver,
   disallowLoadOver,
-  disallowAnyNotEquippedWeapon,
+  disallowNotEquippedInSlot,
+  notEquippedTargetSlots,
   notCarrySameUnitInSameSide,
   notOverEnergyOutput,
   totalCoamNotOverMax,
@@ -37,6 +39,7 @@ describe('validator', () => {
       leftArmUnit: candidates.leftArmUnit.filter(withoutNotEquipped),
       rightBackUnit: candidates.rightBackUnit.filter(withoutNotEquipped),
       leftBackUnit: candidates.leftBackUnit.filter(withoutNotEquipped),
+      expansion: candidates.expansion.filter(withoutNotEquipped),
     }
   })()
 
@@ -306,7 +309,9 @@ describe('validator', () => {
           setWeaponSlot(assembly, key, part)
 
           expect(
-            Result.isSuccess(disallowAnyNotEquippedWeapon.validate(assembly)),
+            Result.isSuccess(
+              disallowNotEquippedInSlot(key as typeof key).validate(assembly),
+            ),
           ).toBe(false)
         },
       )
@@ -316,7 +321,56 @@ describe('validator', () => {
       'should evaluate as valid when all weapons equipped',
       (assembly) => {
         expect(
-          Result.isSuccess(disallowAnyNotEquippedWeapon.validate(assembly)),
+          Result.isSuccess(
+            disallowNotEquippedInSlot('rightArmUnit').validate(assembly),
+          ),
+        ).toBe(true)
+      },
+    )
+  })
+
+  describe('disallow not equipped in slot', () => {
+    const notEquippedBySlot = {
+      rightArmUnit: armNotEquipped,
+      leftArmUnit: armNotEquipped,
+      rightBackUnit: backNotEquipped,
+      leftBackUnit: backNotEquipped,
+      expansion: expansionNotEquipped,
+    } as const
+
+    describe.each(notEquippedTargetSlots)('slot: %s', (slot) => {
+      fcit.prop([genAssembly(candidatesWithoutNotEquipped)])(
+        'should be invalid when the slot is not equipped',
+        (assembly) => {
+          // @ts-expect-error index access for test
+          assembly[slot] = notEquippedBySlot[slot]
+
+          expect(
+            Result.isSuccess(disallowNotEquippedInSlot(slot).validate(assembly)),
+          ).toBe(false)
+        },
+      )
+
+      fcit.prop([genAssembly(candidatesWithoutNotEquipped)])(
+        'should be valid when the slot is equipped',
+        (assembly) => {
+          expect(
+            Result.isSuccess(disallowNotEquippedInSlot(slot).validate(assembly)),
+          ).toBe(true)
+        },
+      )
+    })
+
+    fcit.prop([genAssembly(candidatesWithoutNotEquipped)])(
+      'should be valid when forbidden slot is equipped and other slot is not equipped',
+      (assembly) => {
+        assembly.rightArmUnit = candidatesWithoutNotEquipped.rightArmUnit[0]
+        assembly.leftArmUnit = armNotEquipped
+
+        expect(
+          Result.isSuccess(
+            disallowNotEquippedInSlot('rightArmUnit').validate(assembly),
+          ),
         ).toBe(true)
       },
     )

--- a/packages/core/src/assembly/random/validator/validators.ts
+++ b/packages/core/src/assembly/random/validator/validators.ts
@@ -75,8 +75,7 @@ export const disallowNotEquippedInSlotName = (
 ): `disallowNotEquippedInSlot:${NotEquippedTargetSlot}` =>
   `disallowNotEquippedInSlot:${slot}`
 export const disallowNotEquippedInSlot =
-  (slot: NotEquippedTargetSlot): Validator =>
-  ((): Validator => ({
+  (slot: NotEquippedTargetSlot): Validator => ({
     validate(assembly: Assembly) {
       const part = assembly[slot]
 
@@ -89,7 +88,7 @@ export const disallowNotEquippedInSlot =
           ])
         : Result.succeed(assembly)
     },
-  }))()
+  })
 
 export const totalCoamNotOverMaxName = 'totalCoamNotOverMax'
 export const totalCoamNotOverMax = (max: number): Validator => ({

--- a/packages/core/src/assembly/random/validator/validators.ts
+++ b/packages/core/src/assembly/random/validator/validators.ts
@@ -3,6 +3,7 @@ import { BaseError } from '@philomagi/base-error.js'
 import { Result } from '@praha/byethrow'
 
 import type { Validator } from './base'
+
 import type {
   Assembly,
   AssemblyKey,
@@ -74,21 +75,22 @@ export const disallowNotEquippedInSlotName = (
   slot: NotEquippedTargetSlot,
 ): `disallowNotEquippedInSlot:${NotEquippedTargetSlot}` =>
   `disallowNotEquippedInSlot:${slot}`
-export const disallowNotEquippedInSlot =
-  (slot: NotEquippedTargetSlot): Validator => ({
-    validate(assembly: Assembly) {
-      const part = assembly[slot]
+export const disallowNotEquippedInSlot = (
+  slot: NotEquippedTargetSlot,
+): Validator => ({
+  validate(assembly: Assembly) {
+    const part = assembly[slot]
 
-      return part.classification === notEquipped
-        ? Result.fail([
-            new ValidationError(`${slot} is not equipped`, {
-              validationName: disallowNotEquippedInSlotName(slot),
-              adjustable: true,
-            }),
-          ])
-        : Result.succeed(assembly)
-    },
-  })
+    return part.classification === notEquipped
+      ? Result.fail([
+          new ValidationError(`${slot} is not equipped`, {
+            validationName: disallowNotEquippedInSlotName(slot),
+            adjustable: true,
+          }),
+        ])
+      : Result.succeed(assembly)
+  },
+})
 
 export const totalCoamNotOverMaxName = 'totalCoamNotOverMax'
 export const totalCoamNotOverMax = (max: number): Validator => ({

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,12 +1,10 @@
 # @ac6_assemble_tool/web
 
 ## 4.2.0
+
 ### Minor Changes
 
-
-
 - [#1048](https://github.com/tooppoo/ac6_assemble_tool/pull/1048) [`8a4064c`](https://github.com/tooppoo/ac6_assemble_tool/commit/8a4064c0ca6a70b9c9aeb88c39cdb6e3bf825e56) Thanks [@tooppoo](https://github.com/tooppoo)! - support DisallowNotEquipped
-
 
 ### Patch Changes
 
@@ -185,16 +183,19 @@
 - [#854](https://github.com/tooppoo/ac6_assemble_tool/pull/854) [`1a860f1`](https://github.com/tooppoo/ac6_assemble_tool/commit/1a860f1bc8d7504976e5bf80224bc8757337bdb4) Thanks [@tooppoo](https://github.com/tooppoo)! - # 404.htmlとsitemap.xmlを配置
 
   #### WHY (なぜ)
+
   - SEO向上とユーザビリティ改善のため
   - 検索エンジンのクローラビリティを向上させる必要があった
   - 存在しないページへのアクセス時に適切なエラーページを表示するため
 
   #### WHAT (何を)
+
   - カスタム404エラーページ（404.html）を追加
   - XMLサイトマップ（sitemap.xml）を生成・配置
   - 静的ファイルとしてpublic/staticディレクトリに配置
 
   #### HOW (どのように)
+
   - 404.htmlページを作成し、ユーザーフレンドリーなエラーメッセージを実装
   - sitemap.xmlを自動生成する仕組みをビルドプロセスに組み込み、デプロイ時に自動的に配置されるよう設定
 
@@ -205,6 +206,7 @@
 - [#849](https://github.com/tooppoo/ac6_assemble_tool/pull/849) [`e35425d`](https://github.com/tooppoo/ac6_assemble_tool/commit/e35425d0214a148fbd2dfedf33395bab940ea948) Thanks [@tooppoo](https://github.com/tooppoo)! - # パーツ識別方式をインデックスベースからIDベースへ移行
 
   ## WHAT（破壊的変更の内容）
+
   - **URL共有形式の変更**: インデックスベース（v1: `?h=0&c=1&a=2`）からIDベース（v2: `?v=2&h=HD001&c=CR010&a=AR042`）へ変更
   - **IndexedDBストレージ形式の変更**: パーツをインデックスではなくユニークIDで保存する形式へ変更
 
@@ -213,6 +215,7 @@
   パーツ追加・削除時にインデックスが変動し、既存のURL共有やストレージデータとの互換性が失われる問題を解決するため。各パーツにグローバルユニークID（例: `HD001`, `WP042`）を付与することで、パーツリスト変更時も安定した識別を実現。
 
   ## HOW（ユーザーの対応方法）
+
   - **自動移行**: v1形式のURLとIndexedDBデータは初回アクセス時に自動的にv2形式へ変換されます
   - **注意点**: v2環境で生成したURLやデータはv1環境では動作しません。チーム内でバージョンを統一してください
   - **必要な操作**: なし（自動移行のため手動操作は不要）

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -183,19 +183,16 @@
 - [#854](https://github.com/tooppoo/ac6_assemble_tool/pull/854) [`1a860f1`](https://github.com/tooppoo/ac6_assemble_tool/commit/1a860f1bc8d7504976e5bf80224bc8757337bdb4) Thanks [@tooppoo](https://github.com/tooppoo)! - # 404.htmlとsitemap.xmlを配置
 
   #### WHY (なぜ)
-
   - SEO向上とユーザビリティ改善のため
   - 検索エンジンのクローラビリティを向上させる必要があった
   - 存在しないページへのアクセス時に適切なエラーページを表示するため
 
   #### WHAT (何を)
-
   - カスタム404エラーページ（404.html）を追加
   - XMLサイトマップ（sitemap.xml）を生成・配置
   - 静的ファイルとしてpublic/staticディレクトリに配置
 
   #### HOW (どのように)
-
   - 404.htmlページを作成し、ユーザーフレンドリーなエラーメッセージを実装
   - sitemap.xmlを自動生成する仕組みをビルドプロセスに組み込み、デプロイ時に自動的に配置されるよう設定
 
@@ -206,7 +203,6 @@
 - [#849](https://github.com/tooppoo/ac6_assemble_tool/pull/849) [`e35425d`](https://github.com/tooppoo/ac6_assemble_tool/commit/e35425d0214a148fbd2dfedf33395bab940ea948) Thanks [@tooppoo](https://github.com/tooppoo)! - # パーツ識別方式をインデックスベースからIDベースへ移行
 
   ## WHAT（破壊的変更の内容）
-
   - **URL共有形式の変更**: インデックスベース（v1: `?h=0&c=1&a=2`）からIDベース（v2: `?v=2&h=HD001&c=CR010&a=AR042`）へ変更
   - **IndexedDBストレージ形式の変更**: パーツをインデックスではなくユニークIDで保存する形式へ変更
 
@@ -215,7 +211,6 @@
   パーツ追加・削除時にインデックスが変動し、既存のURL共有やストレージデータとの互換性が失われる問題を解決するため。各パーツにグローバルユニークID（例: `HD001`, `WP042`）を付与することで、パーツリスト変更時も安定した識別を実現。
 
   ## HOW（ユーザーの対応方法）
-
   - **自動移行**: v1形式のURLとIndexedDBデータは初回アクセス時に自動的にv2形式へ変換されます
   - **注意点**: v2環境で生成したURLやデータはv1環境では動作しません。チーム内でバージョンを統一してください
   - **必要な操作**: なし（自動移行のため手動操作は不要）

--- a/packages/web/src/lib/i18n/locales/en/error.ts
+++ b/packages/web/src/lib/i18n/locales/en/error.ts
@@ -10,6 +10,9 @@ import {
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 
+type NotEquippedErrorKey =
+  `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
+
 const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
   switch (slot) {
     case 'rightArmUnit':
@@ -24,6 +27,13 @@ const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
       return 'core expansion not equipped'
   }
 }
+
+const notEquippedErrors = Object.fromEntries(
+  notEquippedTargetSlots.map((slot) => [
+    disallowNotEquippedInSlotName(slot),
+    { label: toNotEquippedLabel(slot) },
+  ]),
+) as Record<NotEquippedErrorKey, { label: string }>
 
 export const enError = {
   assembly: {
@@ -48,15 +58,7 @@ export const enError = {
     [disallowArmsLoadOverName]: {
       label: 'over arm load limit',
     },
-    ...notEquippedTargetSlots.reduce(
-      (acc, slot) => ({
-        ...acc,
-        [disallowNotEquippedInSlotName(slot)]: {
-          label: toNotEquippedLabel(slot),
-        },
-      }),
-      {} as Record<string, { label: string }>,
-    ),
+    ...notEquippedErrors,
     unknown: {
       label: '$t(unknown.label)',
     },

--- a/packages/web/src/lib/i18n/locales/en/error.ts
+++ b/packages/web/src/lib/i18n/locales/en/error.ts
@@ -10,8 +10,7 @@ import {
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 
-type NotEquippedErrorKey =
-  `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
+type NotEquippedErrorKey = `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
 
 const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
   switch (slot) {

--- a/packages/web/src/lib/i18n/locales/en/error.ts
+++ b/packages/web/src/lib/i18n/locales/en/error.ts
@@ -1,12 +1,29 @@
 import {
   disallowArmsLoadOverName,
   disallowLoadOverName,
-  disallowAnyNotEquippedWeaponName,
   notCarrySameUnitInSameSideName,
   notOverEnergyOutputName,
   totalCoamNotOverMaxName,
   totalLoadNotOverMaxName,
+  disallowNotEquippedInSlotName,
+  notEquippedTargetSlots,
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
+import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
+
+const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
+  switch (slot) {
+    case 'rightArmUnit':
+      return 'right arm not equipped'
+    case 'leftArmUnit':
+      return 'left arm not equipped'
+    case 'rightBackUnit':
+      return 'right shoulder not equipped'
+    case 'leftBackUnit':
+      return 'left shoulder not equipped'
+    case 'expansion':
+      return 'core expansion not equipped'
+  }
+}
 
 export const enError = {
   assembly: {
@@ -31,9 +48,15 @@ export const enError = {
     [disallowArmsLoadOverName]: {
       label: 'over arm load limit',
     },
-    [disallowAnyNotEquippedWeaponName]: {
-      label: 'not equipped weapon',
-    },
+    ...notEquippedTargetSlots.reduce(
+      (acc, slot) => ({
+        ...acc,
+        [disallowNotEquippedInSlotName(slot)]: {
+          label: toNotEquippedLabel(slot),
+        },
+      }),
+      {} as Record<string, { label: string }>,
+    ),
     unknown: {
       label: '$t(unknown.label)',
     },

--- a/packages/web/src/lib/i18n/locales/en/random.ts
+++ b/packages/web/src/lib/i18n/locales/en/random.ts
@@ -9,8 +9,20 @@ export const enRandom = {
     disallow_arms_over_load: {
       label: 'Disallow Arms Over Load',
     },
-    disallow_any_not_equipped_weapon: {
-      label: 'Disallow Any Not Equipped Weapon',
+    disallow_not_equipped_right_arm: {
+      label: 'Disallow Right Arm Not Equipped',
+    },
+    disallow_not_equipped_left_arm: {
+      label: 'Disallow Left Arm Not Equipped',
+    },
+    disallow_not_equipped_right_back: {
+      label: 'Disallow Right Shoulder Not Equipped',
+    },
+    disallow_not_equipped_left_back: {
+      label: 'Disallow Left Shoulder Not Equipped',
+    },
+    disallow_not_equipped_expansion: {
+      label: 'Disallow Core Expansion Not Equipped',
     },
   },
   range: {

--- a/packages/web/src/lib/i18n/locales/ja/error.ts
+++ b/packages/web/src/lib/i18n/locales/ja/error.ts
@@ -10,6 +10,9 @@ import {
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 
+type NotEquippedErrorKey =
+  `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
+
 const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
   switch (slot) {
     case 'rightArmUnit':
@@ -24,6 +27,13 @@ const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
       return 'コア拡張未装備'
   }
 }
+
+const notEquippedErrors = Object.fromEntries(
+  notEquippedTargetSlots.map((slot) => [
+    disallowNotEquippedInSlotName(slot),
+    { label: toNotEquippedLabel(slot) },
+  ]),
+) as Record<NotEquippedErrorKey, { label: string }>
 
 export const jaError = {
   assembly: {
@@ -49,15 +59,7 @@ export const jaError = {
     [disallowArmsLoadOverName]: {
       label: '腕部積載超過',
     },
-    ...notEquippedTargetSlots.reduce(
-      (acc, slot) => ({
-        ...acc,
-        [disallowNotEquippedInSlotName(slot)]: {
-          label: toNotEquippedLabel(slot),
-        },
-      }),
-      {} as Record<string, { label: string }>,
-    ),
+    ...notEquippedErrors,
     unknown: {
       label: '$t(unknown.label)',
     },

--- a/packages/web/src/lib/i18n/locales/ja/error.ts
+++ b/packages/web/src/lib/i18n/locales/ja/error.ts
@@ -1,12 +1,29 @@
 import {
   disallowArmsLoadOverName,
   disallowLoadOverName,
-  disallowAnyNotEquippedWeaponName,
   notCarrySameUnitInSameSideName,
   notOverEnergyOutputName,
   totalCoamNotOverMaxName,
   totalLoadNotOverMaxName,
+  disallowNotEquippedInSlotName,
+  notEquippedTargetSlots,
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
+import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
+
+const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
+  switch (slot) {
+    case 'rightArmUnit':
+      return '右腕未装備'
+    case 'leftArmUnit':
+      return '左腕未装備'
+    case 'rightBackUnit':
+      return '右肩未装備'
+    case 'leftBackUnit':
+      return '左肩未装備'
+    case 'expansion':
+      return 'コア拡張未装備'
+  }
+}
 
 export const jaError = {
   assembly: {
@@ -32,9 +49,15 @@ export const jaError = {
     [disallowArmsLoadOverName]: {
       label: '腕部積載超過',
     },
-    [disallowAnyNotEquippedWeaponName]: {
-      label: '武器未装備',
-    },
+    ...notEquippedTargetSlots.reduce(
+      (acc, slot) => ({
+        ...acc,
+        [disallowNotEquippedInSlotName(slot)]: {
+          label: toNotEquippedLabel(slot),
+        },
+      }),
+      {} as Record<string, { label: string }>,
+    ),
     unknown: {
       label: '$t(unknown.label)',
     },

--- a/packages/web/src/lib/i18n/locales/ja/error.ts
+++ b/packages/web/src/lib/i18n/locales/ja/error.ts
@@ -10,8 +10,7 @@ import {
 } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 import type { NotEquippedTargetSlot } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
 
-type NotEquippedErrorKey =
-  `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
+type NotEquippedErrorKey = `disallowNotEquippedInSlot:${NotEquippedTargetSlot}`
 
 const toNotEquippedLabel = (slot: NotEquippedTargetSlot) => {
   switch (slot) {

--- a/packages/web/src/lib/i18n/locales/ja/random.ts
+++ b/packages/web/src/lib/i18n/locales/ja/random.ts
@@ -9,8 +9,20 @@ export const jaRandom = {
     disallow_arms_over_load: {
       label: '腕部積載超過を禁止',
     },
-    disallow_any_not_equipped_weapon: {
-      label: '武器未装備を禁止',
+    disallow_not_equipped_right_arm: {
+      label: '右腕の未装備を禁止',
+    },
+    disallow_not_equipped_left_arm: {
+      label: '左腕の未装備を禁止',
+    },
+    disallow_not_equipped_right_back: {
+      label: '右肩の未装備を禁止',
+    },
+    disallow_not_equipped_left_back: {
+      label: '左肩の未装備を禁止',
+    },
+    disallow_not_equipped_expansion: {
+      label: 'コア拡張の未装備を禁止',
     },
   },
   range: {

--- a/packages/web/src/lib/view/index/random/RandomAssemblyOffCanvas.svelte
+++ b/packages/web/src/lib/view/index/random/RandomAssemblyOffCanvas.svelte
@@ -15,7 +15,8 @@
   import {
     disallowArmsLoadOver,
     disallowLoadOver,
-    disallowAnyNotEquippedWeapon,
+    disallowNotEquippedInSlot,
+    type NotEquippedTargetSlot,
     totalCoamNotOverMax,
     totalLoadNotOverMax,
   } from '@ac6_assemble_tool/core/assembly/random/validator/validators'
@@ -74,6 +75,38 @@
 
     logger.debug('onApply:RandomAssemblyOffCanvas', { param })
   }
+
+  const notEquippedToggles: {
+    slot: NotEquippedTargetSlot
+    key: string
+    labelKey: string
+  }[] = [
+    {
+      slot: 'rightArmUnit',
+      key: 'disallow-not-equipped-right-arm',
+      labelKey: 'random:command.disallow_not_equipped_right_arm.label',
+    },
+    {
+      slot: 'leftArmUnit',
+      key: 'disallow-not-equipped-left-arm',
+      labelKey: 'random:command.disallow_not_equipped_left_arm.label',
+    },
+    {
+      slot: 'rightBackUnit',
+      key: 'disallow-not-equipped-right-back',
+      labelKey: 'random:command.disallow_not_equipped_right_back.label',
+    },
+    {
+      slot: 'leftBackUnit',
+      key: 'disallow-not-equipped-left-back',
+      labelKey: 'random:command.disallow_not_equipped_left_back.label',
+    },
+    {
+      slot: 'expansion',
+      key: 'disallow-not-equipped-expansion',
+      labelKey: 'random:command.disallow_not_equipped_expansion.label',
+    },
+  ]
 </script>
 
 <OffCanvas {id} {open} onToggle={(e) => onToggle?.(e)}>
@@ -142,27 +175,27 @@
       </Switch>
     </div>
     <Margin space={3} />
-    <div id="disallow-any-not-equipped-weapon">
-      <Switch
-        id={`${id}-disallow-any-not-equipped-weapon`}
-        onEnabled={() =>
-          onApply({
-            randomAssembly: randomAssembly.addValidator(
-              'disallow-any-not-equipped-weapon',
-              disallowAnyNotEquippedWeapon,
-            ),
-          })}
-        onDisabled={() =>
-          onApply({
-            randomAssembly: randomAssembly.removeValidator(
-              'disallow-any-not-equipped-weapon',
-            ),
-          })}
-      >
-        {$i18n.t('random:command.disallow_any_not_equipped_weapon.label')}
-      </Switch>
-    </div>
-    <Margin space={3} />
+    {#each notEquippedToggles as toggle}
+      <div id={`disallow-${toggle.slot}-not-equipped`}>
+        <Switch
+          id={`${id}-${toggle.key}`}
+          onEnabled={() =>
+            onApply({
+              randomAssembly: randomAssembly.addValidator(
+                toggle.key,
+                disallowNotEquippedInSlot(toggle.slot),
+              ),
+            })}
+          onDisabled={() =>
+            onApply({
+              randomAssembly: randomAssembly.removeValidator(toggle.key),
+            })}
+        >
+          {$i18n.t(toggle.labelKey)}
+        </Switch>
+      </div>
+      <Margin space={3} />
+    {/each}
     <CoamRangeSlider
       class="my-3 w-100"
       {candidates}

--- a/packages/web/src/lib/view/index/random/RandomAssemblyOffCanvas.svelte
+++ b/packages/web/src/lib/view/index/random/RandomAssemblyOffCanvas.svelte
@@ -175,7 +175,7 @@
       </Switch>
     </div>
     <Margin space={3} />
-    {#each notEquippedToggles as toggle}
+    {#each notEquippedToggles as toggle (toggle.key)}
       <div id={`disallow-${toggle.slot}-not-equipped`}>
         <Switch
           id={`${id}-${toggle.key}`}


### PR DESCRIPTION
## このPRの目的
- Issue #1047 の要望「未装備禁止を部位ごとに切り替えたい」に対応。
- 全体トグルを廃止し、右腕・左腕・右肩・左肩・コア拡張ごとに未装備禁止を設定できるようにする。

## 主な変更点
- バリデータを `disallowNotEquippedInSlot(slot: NotEquippedTargetSlot)` ファクトリに置換し、対象スロットを5部位に限定。
- ランダム組み立てUIの未装備禁止トグルを5分割し、各トグルで対応スロットのバリデータを add/remove。
- i18n（ja/en）のエラーメッセージとランダム生成オプション文言をスロット別に追加。
- `ValidationName` の型をテンプレートリテラル型に拡張し、関連型エラーを解消。
- スロット別バリデータのテストを追加し、禁止スロット装備済み＋非禁止スロット未装備でも成功するケースを検証。

## レビュー観点
- バリデータ名/キー変更による互換性（旧「全体トグル」削除の影響範囲）。
- スロット列挙 `NotEquippedTargetSlot` と i18n キーの整合性。
- ランダム生成UIのトグル組み合わせ挙動（シリアライズ/validator管理への副作用がないか）。

## 関連Issue / ADR
- Issue: #1047
- ADR: なし

## チェックリスト
- [x] 関連するIssueに紐づけた
- [ ] CIが成功している（未実行）
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した

### ローカルで実行した確認
- `pnpm core test`
- `pnpm core run check-types`
