### PR TITLE
EN出力不足などのアラート表示サイズを修正

### DIFF
--- a/.changeset/sweet-hounds-enter.md
+++ b/.changeset/sweet-hounds-enter.md
@@ -1,0 +1,6 @@
+---
+"@ac6_assemble_tool/web": patch
+---
+
+change alert position to avoid layout brakeing
+  

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @ac6_assemble_tool/web
 
 ## 5.0.0
+
 ### Major Changes
-
-
 
 - [#1067](https://github.com/tooppoo/ac6_assemble_tool/pull/1067) [`7dfb380`](https://github.com/tooppoo/ac6_assemble_tool/commit/7dfb3807d513925fa21bd0169b68949e4d1f51ee) Thanks [@tooppoo](https://github.com/tooppoo)! - レイアウト構成変更
 

--- a/packages/web/src/lib/view/index/report/ReportListViewer.svelte
+++ b/packages/web/src/lib/view/index/report/ReportListViewer.svelte
@@ -41,12 +41,12 @@
     <hr />
   {/if}
   <div>
+    {#if block.containProblemFor(assembly)}
+      <div class="alert alert-warning w-75 mx-auto mb-2" role="alert">
+        {$i18n.t(`page/index:report.block.${block.problemCaptionKey}`)}
+      </div>
+    {/if}
     <div class="row mb-3">
-      {#if block.containProblemFor(assembly)}
-        <div class="alert alert-warning w-75 mx-auto mb-2" role="alert">
-          {$i18n.t(`page/index:report.block.${block.problemCaptionKey}`)}
-        </div>
-      {/if}
       {#each block.reports as report (report.key)}
         <ReportItem
           caption={$i18n.t(report.key, { ns: 'assembly' })}


### PR DESCRIPTION
## このPRの目的

画面サイズ次第では、アラートによって画面表示崩れが起きるのを修正

## 主な変更点

アラートを挿入するDOM位置

## レビュー観点

-

## 関連Issue / ADR

- Issue: #
- ADR: #

## チェックリスト

- [ ] 関連するIssueに紐づけた
- [ ] CIが成功している
- [ ] セキュリティやライセンス関連の場合、人間のレビューを依頼した
